### PR TITLE
Ristrutturazione script e riconoscimento della lingua

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 scrape:
 	echo 'start scrapping'
-	python3.11 scripts/getHymns.py
+	python3.11 scripts/getHymns.py "https://nossairmandade.com/hinarios/individual"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4==4.12.3
+langdetect==1.0.9
 nltk==3.8.1
 Requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4==4.12.3
+nltk==3.8.1
+Requests==2.31.0

--- a/scripts/getHymns.py
+++ b/scripts/getHymns.py
@@ -1,105 +1,245 @@
 """ Script for scraping hymns """
 
+import argparse
+import logging
+from urllib.parse import urlparse
 import re
 from pathlib import Path
 import json
 import requests
 from bs4 import BeautifulSoup
 import nltk as k
+from langdetect import detect
+from deepmerge import always_merger
 
-BASE_URL = 'https://nossairmandade.com'
-HYMN_PATHS = ['/hinarios/individual']
-HYMN_DIR = 'hinos'
+SAVE_DIR = 'hinos'
 
-def check_name(name_to_check, list_of_names):
-    """ Check whether there's an omonym, and if so append a counter to the original name """
+
+def check_name(name_to_check, list_of_names, separator='_'):
+    """
+    Controlla che non ci siano omonimi e, in caso affermativo, aggiunge
+    un contantore al termine del nome.
+    """
     if name_to_check not in list_of_names:
         return name_to_check
     counter = 1
-    if len(name_to_check.split('_')) > 1:
+    if len(name_to_check.split(separator)) > 1:
         counter = int(name_to_check.split('_')[1]) + 1
-    return check_name(f"{name_to_check.split('_')[0]}_{counter}", list_of_names)
+    return check_name(f"{name_to_check.split(separator)[0]}{separator}{counter}", list_of_names)
 
+def download_catalog(url, save_hinario=False, save_hino=False):
+    """ Scarica l'intero catalogo. """
+    req = requests.get(url, timeout=10)
+    soup = BeautifulSoup(req.content, 'html.parser')
 
-for path in HYMN_PATHS:
-    response = requests.get(BASE_URL + path, timeout=10)
-    soup = BeautifulSoup(response.content, 'html.parser')
+    catalog = {
+        'title': soup.select('.page_breadcrumbs h2')[0].get_text().strip(),
+        'hinarios': []
+    }
 
-    # Elenca tutte le persone
-    people_raw = soup.select('.col-md-7:not(.col-sm-6)')
-    catalog = {}
-    for person in people_raw:
-        name = check_name(person.find_all('a')[0].get_text(), catalog)
-        catalog[name] = {}
-
-        # Elenca tutti gli hinario per la persona corrente
-        hinarios = person.select('h4 a')
-        for hinario in hinarios:
-            title = hinario.get_text().strip()
-            link = hinario.attrs['href']
-            catalog[name][title] = {'link': link, 'hymns': [] }
-            print(f"{name}, '{title}': {link}")
-
-    # Crea la cartella per salvare i file
-    Path(f"./{HYMN_DIR}").mkdir(parents=True, exist_ok=True)
-
-    # Vaglia ogni persona
-    for person, hinarios in catalog.items():
-        print(f"\n{person.upper()}")
-
-        # Vaglia ogni hinario della persona corrente
-        for hinario in hinarios:
-            HINARIO = {
-                'title': hinario,
-                'received_by': person,
-                'hinos': []
-                }
-            print(f"+ {hinario}:")
-            link = hinarios[hinario]['link']
-            req = requests.get(link, timeout=10)
-            soup = BeautifulSoup(req.content, 'html.parser')
-
-            # Ottieni gli hino contenuti nell'hinario corrente
-            hinos_raw = soup.select('.hymn-list-name a')
-            index = 0
-            for hino in hinos_raw:
-                index += 1
-                hino_link = hino.attrs['href']
-
-                req = requests.get(hino_link, timeout=10)
-                soup = BeautifulSoup(req.content, 'html.parser')
-
-                title = soup.select('.hymn-title h5')[0].get_text().strip()
-                HINO = {
-                    'title': title,
-                    'index': index,
-                    'tokens': [],
-                    'verses': []
-                    }
-                print(f"  - {title}")
-
-                # Analizza le singole strofe
-                stanzas_raw = soup.select('.hymnstanza:has(.hymn-words)')
-                for stanza in stanzas_raw:
-                    repetitions = stanza.select('.hymn-words')
-                    for repetition in repetitions:
-                        verses = re.sub(' +', ' ', repetition.get_text().strip()).split('<br>')
-                        HINO['verses'].extend(verses)
-                        for verse in verses:
-                            tokens = k.word_tokenize(verse)
-                            HINO['tokens'].extend(tokens)
-                
-                # Aggiungi l'hino all'hinario corrente
-                HINARIO['hinos'].append(HINO)
-
-                # Scrivi hino
-                hino_json = json.dumps(HINO, indent=4)
-                filename = f"./{HYMN_DIR}/{person} - {hinario} - {index}. {title}.json"
-                with open(filename, 'w', encoding='utf-8') as outfile:
-                    outfile.write(hino_json)
-            
-            # Scrivi hinario
-            hinario_json = json.dumps(HINARIO, indent=4)
-            filename = f"./{HYMN_DIR}/{person} - {hinario}.json"
+    hinarios_raw = soup.select('h4 a')
+    for hinario_raw in hinarios_raw:
+        hinario_url = hinario_raw.attrs['href']
+        hinario = download_hinario(hinario_url, save_hino=save_hino)
+        if save_hinario:
+            hinario_json = json.dumps(hinario, indent=4)
+            filename = f"./{SAVE_DIR}/{hinario['person']} - {hinario['title']}.json"
             with open(filename, 'w', encoding='utf-8') as outfile:
                 outfile.write(hinario_json)
+        catalog['hinarios'].append(hinario)
+    return catalog
+
+def download_hinario(url, save_hino=False):
+    """ Scarica il singolo hinario con tutti gli hino a lui relativi. """
+    logging.debug('Scarico hinario: %s', url)
+
+    req = requests.get(url, timeout=10)
+    soup = BeautifulSoup(req.content, 'html.parser')
+
+    hinario = {
+        'person': soup.select('.breadcrumb li:nth-last-of-type(2) a')[0].get_text().strip(),
+        'title': soup.select('.page_breadcrumbs h2')[0].find(string=True, recursive=False).get_text().strip(),
+        'hinos': []
+    }
+
+    logging.info('+ %s', hinario['title'])
+
+    hinos_raw = soup.select('.hymn-list-name a')
+    for hino_raw in hinos_raw:
+        hino_url = hino_raw.attrs['href']
+        hino = download_hino(hino_url, hinario['title'])
+        if save_hino:
+            hino_json = json.dumps(hino, indent=4)
+            filename = f"./{SAVE_DIR}/{hino['person']} - {hino['hinario']} - {hino['index']}. {hino['title']}.json"
+            with open(filename, 'w', encoding='utf-8') as outfile:
+                outfile.write(hino_json)
+        # Essendo già presenti nei dati dell'hinario, chi lo ha ricevuto
+        # e il titolo sono informazioni ridondanti.
+        del hino['person']
+        del hino['hinario']
+        hinario['hinos'].append(hino)
+    return hinario
+
+def download_hino(url, hinario=''):
+    """ Scarica un singolo hino. """
+    logging.debug('Scarico hino: %s', url)
+
+    req = requests.get(url, timeout=10)
+    soup = BeautifulSoup(req.content, 'html.parser')
+
+    index = soup.select('.hinario-breadcrumb-hinario a')[0].get_text().strip().split('#')[1]
+
+    # Se alla funzione non viene passato il titolo dell'hinario, significa che
+    # si sta scaricando il singolo hino, e perciò verranno presi per validi
+    # il titolo e l'indice nella barra principale.
+    if hinario == '':
+        hinario = soup.select('.hinario-breadcrumb-hinario a')[0].get_text().strip().split('#')[0]
+    else:
+        # Se invece viene passato il titolo, per recuperare l'indice corretto
+        # è necessario selezionare l'indice relativo all'hinario interessato
+        # in quanto lo stesso hino può figurare in più di un hinariol
+        sources_raw = soup.select('.hinario-breadcrumb-hinario')
+        for source_raw in sources_raw:
+            source = source_raw.get_text().split('#')[0].strip()
+            if source == hinario:
+                index = source_raw.get_text().split('#')[1].strip()
+                break
+
+    hino = {
+        'person': soup.select('.breadcrumb li:nth-of-type(1) a')[0].get_text().strip(),
+        'hinario': hinario,
+        'index': index,
+        'title': soup.select('.hymn-title h5')[0].get_text().strip(),
+        'verses': [],
+        'tokens': {},
+        }
+
+    logging.info('  - %s. %s', hino['index'], hino['title'])
+
+    # Analizza le singole strofe
+    stanzas_raw = soup.select('.hymnstanza:has(.hymn-words)')
+    for stanza in stanzas_raw:
+        repetitions = stanza.select('.hymn-words')
+        for repetition in repetitions:
+            text = re.sub(' +', ' ', repetition.get_text().strip()).split('<br>')[0]
+            if text != '':
+                lang = detect(text)
+                verses = {
+                    'text': text,
+                    'lang': lang
+                }
+                tokens = { lang: k.word_tokenize(text) }
+                hino['verses'].append(verses)
+                hino['tokens'] = always_merger.merge(hino['tokens'], tokens)
+    return hino
+
+def download_person(url, save_hinario=False, save_hino=False):
+    """ Scarica tutti gli hinari ricevuti da una singola persona. """
+    logging.debug('Scarico persona: %s', url)
+    req = requests.get(url, timeout=10)
+    soup = BeautifulSoup(req.content, 'html.parser')
+
+    person = {
+        'name': soup.select('.page_breadcrumbs h2')[0].get_text().strip(),
+        'hinarios': []
+    }
+
+    hinarios_raw = soup.select('.row .no-bullets li a')
+    for hinario_raw in hinarios_raw:
+        hinario_url = hinario_raw.attrs['href']
+        hinario = download_hinario(hinario_url, save_hino=save_hino)
+        if save_hinario:
+            hinario_json = json.dumps(hinario, indent=4)
+            filename = f"./{SAVE_DIR}/{hinario['person']} - {hinario['title']}.json"
+            with open(filename, 'w', encoding='utf-8') as outfile:
+                outfile.write(hinario_json)
+        # Rimuovo il nome della persona che lo ha ricevuto perché già indicato.
+        del hinario['person']
+        person['hinarios'].append(hinario)
+    return person
+
+def main():
+    """ Funzione principale. """
+
+    parser = argparse.ArgumentParser(
+                        prog='getHymns',
+                        )
+    parser.add_argument('url',
+                        help='URL da scaricare',
+                        nargs='+'
+                        )
+    parser.add_argument('--debug',
+                        action='store_true'
+                        )
+    parser.add_argument('--save-catalog',
+                        default=True,
+                        action='store_true',
+                        help='Salva tutto in un unico file'
+                        )
+    parser.add_argument('--save-person',
+                        default=False,
+                        action='store_true',
+                        help='Salva tutto ciò che ha ricevugto una persona in un singolo file'
+                        )
+    parser.add_argument('--save-hinario',
+                        default=False,
+                        action='store_true',
+                        help='Salva ogni hinario in un file separato'
+                        )
+    parser.add_argument('--save-hino',
+                        default=False,
+                        action='store_true',
+                        help='Salva ogni hino in un file separato'
+                        )
+    args = parser.parse_args()
+
+    if args.save_catalog or args.save_person or args.save_hinario or args.save_hino:
+        Path(f"./{SAVE_DIR}").mkdir(parents=True, exist_ok=True)
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    for url in args.url:
+        logging.debug('Working on %s', url)
+        try:
+            o = urlparse(url)
+            if o.netloc != 'nossairmandade.com':
+                raise ValueError(f"{o.netloc} non è supportato.")
+            match o.path.split('/')[1]:
+                case 'hinarios':
+                    catalog = download_catalog(url, save_hinario=args.save_hinario, save_hino=args.save_hino)
+                    if args.save_catalog:
+                        catalog_json = json.dumps(catalog, indent=4)
+                        filename = f"./{SAVE_DIR}/{catalog['title']}.json"
+                        with open(filename, 'w', encoding='utf-8') as outfile:
+                            outfile.write(catalog_json)
+                case 'person':
+                    person = download_person(url, save_hinario=args.save_hinario, save_hino=args.save_hino)
+                    if args.save_person:
+                        person_json = json.dumps(person, indent=4)
+                        filename = f"./{SAVE_DIR}/{person['name']}.json"
+                        with open(filename, 'w', encoding='utf-8') as outfile:
+                            outfile.write(person_json)
+                case 'hinario':
+                    hinario = download_hinario(url, save_hino=args.save_hino)
+                    if args.save_hinario:
+                        hinario_json = json.dumps(hinario, indent=4)
+                        filename = f"./{SAVE_DIR}/{hinario['person']} - {hinario['title']}.json"
+                        with open(filename, 'w', encoding='utf-8') as outfile:
+                            outfile.write(hinario_json)
+                case 'hymn':
+                    hino = download_hino(url)
+                    if args.save_hino:
+                        hino_json = json.dumps(hino, indent=4)
+                        filename = f"./{SAVE_DIR}/{hino['person']} - {hino['hinario']} - {hino['index']}. {hino['title']}.json"
+                        with open(filename, 'w', encoding='utf-8') as outfile:
+                            outfile.write(hino_json)
+                case other:
+                    raise ValueError(f"Non so cosa fare con {o.path.split('/')[1]}.")
+        except ValueError:
+            logging.error("Non posso lavorare su %s. Vado avanti...", %s)
+            continue
+
+if __name__ == "__main__":
+    main()

--- a/scripts/getHymns.py
+++ b/scripts/getHymns.py
@@ -238,7 +238,7 @@ def main():
                 case other:
                     raise ValueError(f"Non so cosa fare con {o.path.split('/')[1]}.")
         except ValueError:
-            logging.error("Non posso lavorare su %s. Vado avanti...", %s)
+            logging.error('Non posso lavorare su %s. Vado avanti...', url)
             continue
 
 if __name__ == "__main__":

--- a/scripts/getHymns.py
+++ b/scripts/getHymns.py
@@ -1,124 +1,105 @@
+""" Script for scraping hymns """
+
+import re
+from pathlib import Path
+import json
 import requests
 from bs4 import BeautifulSoup
 import nltk as k
-import os
 
-base_url = 'https://nossairmandade.com'
-hymn_path = '/hinarios/individual'  # Add other paths if needed
-hymn_dir = 'hinos'  # folder were text files will be written
-response = requests.get(base_url + hymn_path)
+BASE_URL = 'https://nossairmandade.com'
+HYMN_PATHS = ['/hinarios/individual']
+HYMN_DIR = 'hinos'
 
-soup = BeautifulSoup(response.content, 'html.parser')
-donos2 = soup.find_all('div', 'col-md-7')  # parece ter 1 a mais
+def check_name(name_to_check, list_of_names):
+    """ Check whether there's an omonym, and if so append a counter to the original name """
+    if name_to_check not in list_of_names:
+        return name_to_check
+    counter = 1
+    if len(name_to_check.split('_')) > 1:
+        counter = int(name_to_check.split('_')[1]) + 1
+    return check_name(f"{name_to_check.split('_')[0]}_{counter}", list_of_names)
 
-donos = {}  # hymn "owner", the person who "received" it
-achados = []  # found hymnals
-for num, dono in enumerate(donos2):  # finding owners and her hymnals
-    try:
-        nome = dono.find_all('a')[0].get_text()
-        if nome == 'Jump to list of individuals':
-            continue
-        # TODO: check that dono is unique in donos2
-        if nome in donos:
-            raise Exception('FIXME: A hymnal owner is being overwritten')
-        donos[nome] = {}
 
-        a_ = dono.find_all('h4')
-        for i in a_:
-            a = i.a
-            link = a['href']
-            hinario = a.get_text().strip()
-            print(nome, hinario, link)
-            achados.append((nome, hinario, link))  # useful for debugging / developing
-            donos[nome][hinario] = { 'link': link, 'hymns': [] }  # useful for reaching final text files
-    except:
-        print('something went bad with donos2 item in index:', num)
+for path in HYMN_PATHS:
+    response = requests.get(BASE_URL + path, timeout=10)
+    soup = BeautifulSoup(response.content, 'html.parser')
 
-# check donos dictionary is as expected
-for dono in donos:
-    for hinario_name in donos[dono]:
-        hinario = donos[dono][hinario_name]
-        link = hinario['link']
-        r = requests.get(link)
-        s = BeautifulSoup(r.content, 'html.parser')
+    # Elenca tutte le persone
+    people_raw = soup.select('.col-md-7:not(.col-sm-6)')
+    catalog = {}
+    for person in people_raw:
+        name = check_name(person.find_all('a')[0].get_text(), catalog)
+        catalog[name] = {}
 
-        hinos = s.find_all('div', 'hymn-list-name')  # parece ter 1 a mais
-        hinos_ = []
-        HINOS = {}
-        count = 0
-        for h in hinos[:1]:
-            nome = h.get_text().strip()
-            link = h.a['href']
+        # Elenca tutti gli hinario per la persona corrente
+        hinarios = person.select('h4 a')
+        for hinario in hinarios:
+            title = hinario.get_text().strip()
+            link = hinario.attrs['href']
+            catalog[name][title] = {'link': link, 'hymns': [] }
+            print(f"{name}, '{title}': {link}")
 
-            hinos_.append((nome, link))
+    # Crea la cartella per salvare i file
+    Path(f"./{HYMN_DIR}").mkdir(parents=True, exist_ok=True)
 
-            # finally opening an hymn:
-            r2 = requests.get(link)
-            s2 = BeautifulSoup(r2.content, 'html.parser')
-            title = s2.find_all('div', 'hymn-title')[0].get_text().strip()
+    # Vaglia ogni persona
+    for person, hinarios in catalog.items():
+        print(f"\n{person.upper()}")
 
-            # maybe assert(title == nome) ??
-            # ===> title parece mais limpo que nome
-            estrofes = s2.find_all('div', 'hymnstanza')
-            HINO = dict(tokens=[], versos=[], title=title)
-            for e in estrofes:
-                repeticoes = e.find_all('div', 'hymn-words')
-                for r in repeticoes:
-                    versos = r.get_text().strip().split('<br>')
-                    HINO['versos'].extend(versos)
-                    for verso in versos:
-                        tokens = k.word_tokenize(verso)
-                        HINO['tokens'].extend(tokens)
-            HINOS[h] = HINO
-            hinario['hymns'].append(HINO)
-            print(count)
-            count += 1
+        # Vaglia ogni hinario della persona corrente
+        for hinario in hinarios:
+            HINARIO = {
+                'title': hinario,
+                'received_by': person,
+                'hinos': []
+                }
+            print(f"+ {hinario}:")
+            link = hinarios[hinario]['link']
+            req = requests.get(link, timeout=10)
+            soup = BeautifulSoup(req.content, 'html.parser')
 
-# qua manca:
-# capire se donos dict finisce con una buona struttura di dato
-# scrivere tutto come un solo file JSON, dopo apriamo questo JSON
-# sia in JS per la webpage, che in Python per analisi numeriche e locali
+            # Ottieni gli hino contenuti nell'hinario corrente
+            hinos_raw = soup.select('.hymn-list-name a')
+            index = 0
+            for hino in hinos_raw:
+                index += 1
+                hino_link = hino.attrs['href']
 
-# se possibile:
-# pulire lo script, mi sembra che ci sono degli oggetti non necessari.
-# scrivere tutto in inglese o italiano o portoghese. Preferisco l'italiano
-# capire se possiamo rimouvere lo script di sotto:
+                req = requests.get(hino_link, timeout=10)
+                soup = BeautifulSoup(req.content, 'html.parser')
 
-######## cancellare?
-# achados_ = [i for i in achados if i[0] != 'Jump to list of individuals']
-# achados_.pop(3)  # o mestre diz, é uma gravação
-# 
-# hinarios = {}
-# for a in achados_[:10]:
-#     r = requests.get(a[2])
-#     s = BeautifulSoup(r.content, 'html.parser')
-#     hinos = s.find_all('div', 'hymn-list-name')  # parece ter 1 a mais
-#     hinos_ = []
-#     HINOS = {}
-#     count = 0
-#     for h in hinos[:1]:
-#         nome = h.get_text().strip()
-#         link = h.a['href']
-#         hinos_.append((nome, link))
-#         r2 = requests.get(link)
-#         s2 = BeautifulSoup(r2.content, 'html.parser')
-#         title = s2.find_all('div', 'hymn-title')[0].get_text().strip()
-#         # assert(title == nome)
-#         # ===> title mais limpo que nome
-#         estrofes = s2.find_all('div', 'hymnstanza')
-#         HINO = dict(tokens=[], versos=[])
-#         for e in estrofes:
-#             repeticoes = e.find_all('div', 'hymn-words')
-#             for r in repeticoes:
-#                 versos = r.get_text().strip().split('<br>')
-#                 HINO['versos'].extend(versos)
-#                 for verso in versos:
-#                     tokens = k.word_tokenize(verso)
-#                     HINO['tokens'].extend(tokens)
-#         HINOS[h] = HINO
-#         print(count)
-#         count += 1
-#     hinarios[a] = HINOS
-# 
-# # qua manca:
-######
+                title = soup.select('.hymn-title h5')[0].get_text().strip()
+                HINO = {
+                    'title': title,
+                    'index': index,
+                    'tokens': [],
+                    'verses': []
+                    }
+                print(f"  - {title}")
+
+                # Analizza le singole strofe
+                stanzas_raw = soup.select('.hymnstanza:has(.hymn-words)')
+                for stanza in stanzas_raw:
+                    repetitions = stanza.select('.hymn-words')
+                    for repetition in repetitions:
+                        verses = re.sub(' +', ' ', repetition.get_text().strip()).split('<br>')
+                        HINO['verses'].extend(verses)
+                        for verse in verses:
+                            tokens = k.word_tokenize(verse)
+                            HINO['tokens'].extend(tokens)
+                
+                # Aggiungi l'hino all'hinario corrente
+                HINARIO['hinos'].append(HINO)
+
+                # Scrivi hino
+                hino_json = json.dumps(HINO, indent=4)
+                filename = f"./{HYMN_DIR}/{person} - {hinario} - {index}. {title}.json"
+                with open(filename, 'w', encoding='utf-8') as outfile:
+                    outfile.write(hino_json)
+            
+            # Scrivi hinario
+            hinario_json = json.dumps(HINARIO, indent=4)
+            filename = f"./{HYMN_DIR}/{person} - {hinario}.json"
+            with open(filename, 'w', encoding='utf-8') as outfile:
+                outfile.write(hinario_json)

--- a/scripts/getHymns.py
+++ b/scripts/getHymns.py
@@ -18,13 +18,13 @@ SAVE_DIR = 'hinos'
 def check_name(name_to_check, list_of_names, separator='_'):
     """
     Controlla che non ci siano omonimi e, in caso affermativo, aggiunge
-    un contantore al termine del nome.
+    un contatore al termine del nome.
     """
     if name_to_check not in list_of_names:
         return name_to_check
     counter = 1
     if len(name_to_check.split(separator)) > 1:
-        counter = int(name_to_check.split('_')[1]) + 1
+        counter = int(name_to_check.split(separator)[1]) + 1
     return check_name(f"{name_to_check.split(separator)[0]}{separator}{counter}", list_of_names)
 
 def download_catalog(url, save_hinario=False, save_hino=False):
@@ -62,7 +62,7 @@ def download_hinario(url, save_hino=False):
         'hinos': []
     }
 
-    logging.info('+ %s', hinario['title'])
+    logging.info('+ %s (%s)', hinario['title'], hinario['person'])
 
     hinos_raw = soup.select('.hymn-list-name a')
     for hino_raw in hinos_raw:


### PR DESCRIPTION
Ho ristrutturato lo script per poter fare debug sui singoli URL, ma attraverso il make così modificato funziona come prima.

Il comportamento di default consiste nel fare lo scrape e salvare un unico file per l’intero catalogo. Ogni verso viene contrassegnato con la lingua riconosciuta da `langdetect` così che si possa considerare o escludere nelle analisi a seconda dell’occorrenza.

Testato sull’URL principale, sembra funzionare senza intoppi. 🤞🏻🤞🏻