### PR TITLE
Aggiunta delle ripetizioni

### DIFF
--- a/scripts/getHymns.py
+++ b/scripts/getHymns.py
@@ -238,14 +238,20 @@ def main():
                 raise ValueError(f"{o.netloc} non è supportato.")
             match o.path.split('/')[1]:
                 case 'hinarios':
-                    catalog = download_catalog(url, save_hinario=args.save_hinario, save_hino=args.save_hino)
+                    catalog = download_catalog(url,
+                                               save_hinario=args.save_hinario,
+                                               save_hino=args.save_hino
+                                               )
                     if args.save_catalog:
                         catalog_json = json.dumps(catalog, indent=4)
                         filename = f"./{SAVE_DIR}/{catalog['title']}.json"
                         with open(filename, 'w', encoding='utf-8') as outfile:
                             outfile.write(catalog_json)
                 case 'person':
-                    person = download_person(url, save_hinario=args.save_hinario, save_hino=args.save_hino)
+                    person = download_person(url,
+                                             save_hinario=args.save_hinario,
+                                             save_hino=args.save_hino
+                                             )
                     if args.save_person:
                         person_json = json.dumps(person, indent=4)
                         filename = f"./{SAVE_DIR}/{person['name']}.json"


### PR DESCRIPTION
Ho modificato lo script perché registri le ripetizioni. Ora i versi sono registrati in maniera pulita e ho perciò rimosso la tokenizzazione.

Gli schemi di ripetizione sono calcolati sulle singole strofe. Se una strofa non ha lo schema esplicito, viene considerato l'ultimo schema applicato. All'interno di ogni hino c'è la voce `text` che contiene i testi nelle singole lingue. Ogni strofa ha un suo dict che riporta lo schema di ripetizione e la lista dei versi. In questo modo si può calcolare verso per verso se ricade all'interno di uno schema di ripetizioni.

```python
'text': {
        'pt': [
          {
              'reps_pattern': [
                  {
                     'from': block_index,
                     'to': block_index + block_length - 1,
                     'reps': reps
                 }
              ],
              'verses': [
                'verso 1',
                'verso 2,
                ...
              ]
        ],
        'en': [
          ...
        ],
        ...
    }
```

Dato che le eccezioni sono mille, ogni hino viene controllato e flaggato se:
1. ci sono lingue oltre a pt e en
2. se le strofe al suo interno hanno lunghezza variabile (utile per [Rogativo dos Mortos](https://nossairmandade.com/hymn/167/RogativoDosMortos) ma anche per [O Prensor](https://nossairmandade.com/hymn/233/OPrensor), in cui alcune strofe non seguono la ripetizione dell'ultima strofa ma di una precedente).
3. se ci sono versi vuoti. In questo caso il flag è un generico "other" dovuto al fatto che l'errore parte dal riconoscimento della lingua che non può avvenire su un testo vuoto.
