### PR TITLE
Add hymn similarity analysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
       <canvas id="contentCanvas" width="1000" height="500" style="width:100%">
       </canvas>
     </div>
+    <div id="similarDiv" style="text-align:center;margin-top:2%">
+    </div>
   <script type="module" src="scripts/bundle.js"></script>
   <input id="file-input" type="file" name="name" style="display: none;" />
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2,6 +2,7 @@ console.log('scripts/main.js being executed YAUIASHUDAS')
 const $ = require('jquery')
 const WordCloud = require('wordcloud')
 window.jQuery = $
+let hinarioSets = []
 
 // load the JSON file from the hymns
 // plot hymn words according to the selected hymn
@@ -23,18 +24,21 @@ $.getJSON('hinos/td.json', function (data) {
       // hinário
       // cada hino
       plotWordcloud(e)
+      updateSimilarHinarios(Number(ii))
     })
 
   // const cd = $('<div/>', { id: 'contentDiv' }).appendTo('body')
   // $('<canvas/>', { id: 'contentCanvas', width: '1000' }).appendTo(cd)
 
   window.adata = data
+  hinarioSets = data.hinarios.map(h => collectTokenSet(h))
   data.hinarios.forEach((i, count) => {
     const aname = `${i.title} - ${i.person}`
     s.append($('<option/>', { class: 'pres' }).val(count).html(aname))
     $('#loading').hide()
   })
   plotWordcloud(data.hinarios[0])
+  updateSimilarHinarios(0)
 })
 
 function plotWordcloud (hinario) {
@@ -286,3 +290,34 @@ const punct = [
 ]
 
 const stopWords_ = [...stopWords, ...punct]
+
+function collectTokenSet (hinario) {
+  const tokens = hinario.hinos.reduce((a, h) => {
+    if (h.tokens && h.tokens.pt) return [...a, ...h.tokens.pt]
+    return a
+  }, [])
+  const lower = tokens.map(t => t.toLowerCase())
+  return new Set(lower.filter(t => !stopWords_.includes(t)))
+}
+
+function jaccard (setA, setB) {
+  const inter = [...setA].filter(x => setB.has(x))
+  const union = new Set([...setA, ...setB])
+  return inter.length / union.size
+}
+
+function updateSimilarHinarios (index) {
+  const base = hinarioSets[index]
+  const sims = hinarioSets.map((set, i) => {
+    if (i === index) return null
+    return { i, s: jaccard(base, set) }
+  }).filter(Boolean).sort((a, b) => b.s - a.s).slice(0, 3)
+  const div = $('#similarDiv').empty()
+  $('<h3/>').text('Similar Hymnals').appendTo(div)
+  const ul = $('<ul/>').appendTo(div)
+  sims.forEach(m => {
+    const h = window.adata.hinarios[m.i]
+    const label = `${h.title} - ${h.person} (${m.s.toFixed(2)})`
+    $('<li/>').text(label).appendTo(ul)
+  })
+}


### PR DESCRIPTION
## Summary
- add container to show similar hymnals on the page
- compute vocabulary sets for each hymnal
- show the most similar hymnals when one is selected

## Testing
- `npx standard`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687aa2dbb8c48325a055ad22ccd11543