### PR TITLE
Add wordcloud click modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,16 @@
       <canvas id="contentCanvas" width="1000" height="500"></canvas>
       <div id="similarDiv"></div>
     </div>
+    <div id="wordModal" class="modal">
+      <div class="modal-content">
+        <span class="close">&times;</span>
+        <p id="modalWord"></p>
+      </div>
+    </div>
     <script type="module" src="scripts/bundle.js"></script>
     <input id="file-input" type="file" name="name" style="display: none;" />
 
-</body>
+  </body>
 <style type="text/css">
 #loading {
   display: block;

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -11962,6 +11962,19 @@ const WordCloud = require('wordcloud')
 window.jQuery = $
 let hinarioSets = []
 
+function showWordDetail (item) {
+  const [word, count] = item
+  $('#modalWord').text(`${word} - ${count}x`)
+  $('#wordModal').show()
+}
+
+$(function () {
+  $('#wordModal .close').on('click', () => $('#wordModal').hide())
+  $('#wordModal').on('click', e => {
+    if (e.target.id === 'wordModal') $('#wordModal').hide()
+  })
+})
+
 // load the JSON file from the hymns
 // plot hymn words according to the selected hymn
 $.getJSON('hinos/td.json', function (data) {
@@ -12024,7 +12037,11 @@ function plotWordcloud (hinario) {
   //   html: items.join('')
   // }).appendTo('#contentDiv')
   const list = tokensHist.map(i => [i.t, i.count])
-  WordCloud(document.getElementById('contentCanvas'), { list, weightFactor: 100 / tokensHist[0].count })
+  WordCloud(document.getElementById('contentCanvas'), {
+    list,
+    weightFactor: 100 / tokensHist[0].count,
+    click: showWordDetail
+  })
 
   window.th = { tokensHist, list }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,6 +4,19 @@ const WordCloud = require('wordcloud')
 window.jQuery = $
 let hinarioSets = []
 
+function showWordDetail (item) {
+  const [word, count] = item
+  $('#modalWord').text(`${word} - ${count}x`)
+  $('#wordModal').show()
+}
+
+$(function () {
+  $('#wordModal .close').on('click', () => $('#wordModal').hide())
+  $('#wordModal').on('click', e => {
+    if (e.target.id === 'wordModal') $('#wordModal').hide()
+  })
+})
+
 // load the JSON file from the hymns
 // plot hymn words according to the selected hymn
 $.getJSON('hinos/td.json', function (data) {
@@ -66,7 +79,11 @@ function plotWordcloud (hinario) {
   //   html: items.join('')
   // }).appendTo('#contentDiv')
   const list = tokensHist.map(i => [i.t, i.count])
-  WordCloud(document.getElementById('contentCanvas'), { list, weightFactor: 100 / tokensHist[0].count })
+  WordCloud(document.getElementById('contentCanvas'), {
+    list,
+    weightFactor: 100 / tokensHist[0].count,
+    click: showWordDetail
+  })
 
   window.th = { tokensHist, list }
 }


### PR DESCRIPTION
## Summary
- add modal markup for word details
- add click handler in `scripts/main.js`
- rebuild JS bundle

## Testing
- `npx standard`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687aba30da0483259aa2939bf0a7b9ce