### PR TITLE
Fix fullscreen wordcloud interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,12 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+:fullscreen #contentCanvas {
+  max-width: none;
+  width: 100vw;
+  height: 100vh;
+}
+
 #canvasContainer {
   position: relative;
   display: inline-block;

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -11974,13 +11974,24 @@ $(function () {
     if (e.target.id === 'wordModal') $('#wordModal').hide()
   })
   $('#fullscreenBtn').on('click', () => {
-    const canvas = document.getElementById('contentCanvas')
-    if (canvas.requestFullscreen) {
-      canvas.requestFullscreen()
-    } else if (canvas.webkitRequestFullscreen) {
-      canvas.webkitRequestFullscreen()
-    } else if (canvas.msRequestFullscreen) {
-      canvas.msRequestFullscreen()
+    const doc = document
+    if (!doc.fullscreenElement && !doc.webkitFullscreenElement && !doc.msFullscreenElement) {
+      const elem = document.documentElement
+      if (elem.requestFullscreen) {
+        elem.requestFullscreen()
+      } else if (elem.webkitRequestFullscreen) {
+        elem.webkitRequestFullscreen()
+      } else if (elem.msRequestFullscreen) {
+        elem.msRequestFullscreen()
+      }
+    } else {
+      if (doc.exitFullscreen) {
+        doc.exitFullscreen()
+      } else if (doc.webkitExitFullscreen) {
+        doc.webkitExitFullscreen()
+      } else if (doc.msExitFullscreen) {
+        doc.msExitFullscreen()
+      }
     }
   })
 })

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -16,13 +16,24 @@ $(function () {
     if (e.target.id === 'wordModal') $('#wordModal').hide()
   })
   $('#fullscreenBtn').on('click', () => {
-    const canvas = document.getElementById('contentCanvas')
-    if (canvas.requestFullscreen) {
-      canvas.requestFullscreen()
-    } else if (canvas.webkitRequestFullscreen) {
-      canvas.webkitRequestFullscreen()
-    } else if (canvas.msRequestFullscreen) {
-      canvas.msRequestFullscreen()
+    const doc = document
+    if (!doc.fullscreenElement && !doc.webkitFullscreenElement && !doc.msFullscreenElement) {
+      const elem = document.documentElement
+      if (elem.requestFullscreen) {
+        elem.requestFullscreen()
+      } else if (elem.webkitRequestFullscreen) {
+        elem.webkitRequestFullscreen()
+      } else if (elem.msRequestFullscreen) {
+        elem.msRequestFullscreen()
+      }
+    } else {
+      if (doc.exitFullscreen) {
+        doc.exitFullscreen()
+      } else if (doc.webkitExitFullscreen) {
+        doc.webkitExitFullscreen()
+      } else if (doc.msExitFullscreen) {
+        doc.msExitFullscreen()
+      }
     }
   })
 })


### PR DESCRIPTION
## Summary
- make fullscreen toggle use the whole document
- style canvas when fullscreen to occupy available space

## Testing
- `npm run build`
- `npx standard`


------
https://chatgpt.com/codex/tasks/task_e_687ac4a32c048325a97572f877a24e90