### PR TITLE
Add hymnal statistics display

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         <button id="fullscreenBtn" title="View wordcloud full screen">&#x26F6;</button>
       </div>
       <div id="similarDiv"></div>
+        <div id="statsDiv"></div>
     </div>
     <div id="wordModal" class="modal">
       <div class="modal-content">
@@ -95,6 +96,15 @@
 }
 
 #similarDiv ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+#statsDiv {
+  max-width: 300px;
+}
+
+#statsDiv ul {
   list-style-type: none;
   padding-left: 0;
 }

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -12017,6 +12017,7 @@ $.getJSON('hinos/td.json', function (data) {
       // cada hino
       plotWordcloud(e)
       updateSimilarHinarios(Number(ii))
+      updateStats(Number(ii))
     })
 
   // const cd = $('<div/>', { id: 'contentDiv' }).appendTo('body')
@@ -12031,6 +12032,7 @@ $.getJSON('hinos/td.json', function (data) {
   })
   plotWordcloud(data.hinarios[0])
   updateSimilarHinarios(0)
+  updateStats(0)
 })
 
 function plotWordcloud (hinario) {
@@ -12316,6 +12318,27 @@ function updateSimilarHinarios (index) {
     const label = `${h.title} - ${h.person} (${m.s.toFixed(2)})`
     $('<li/>').text(label).appendTo(ul)
   })
+}
+
+function computeStats (hinario) {
+  const tokens = hinario.hinos.reduce((a, h) => {
+    if (h.tokens && h.tokens.pt) return [...a, ...h.tokens.pt]
+    return a
+  }, [])
+  const hymnsCount = hinario.hinos.length
+  const tokenCount = tokens.length
+  const uniqueTokens = new Set(tokens.map(t => t.toLowerCase())).size
+  return { hymnsCount, tokenCount, uniqueTokens }
+}
+
+function updateStats (index) {
+  const stats = computeStats(window.adata.hinarios[index])
+  const div = $('#statsDiv').empty()
+  $('<h3/>').text('Hymnal Stats').appendTo(div)
+  const ul = $('<ul/>').appendTo(div)
+  $('<li/>').text(`Hymns: ${stats.hymnsCount}`).appendTo(ul)
+  $('<li/>').text(`Total words: ${stats.tokenCount}`).appendTo(ul)
+  $('<li/>').text(`Unique words: ${stats.uniqueTokens}`).appendTo(ul)
 }
 
 },{"jquery":1,"wordcloud":2}]},{},[3]);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -59,6 +59,7 @@ $.getJSON('hinos/td.json', function (data) {
       // cada hino
       plotWordcloud(e)
       updateSimilarHinarios(Number(ii))
+      updateStats(Number(ii))
     })
 
   // const cd = $('<div/>', { id: 'contentDiv' }).appendTo('body')
@@ -73,6 +74,7 @@ $.getJSON('hinos/td.json', function (data) {
   })
   plotWordcloud(data.hinarios[0])
   updateSimilarHinarios(0)
+  updateStats(0)
 })
 
 function plotWordcloud (hinario) {
@@ -358,4 +360,25 @@ function updateSimilarHinarios (index) {
     const label = `${h.title} - ${h.person} (${m.s.toFixed(2)})`
     $('<li/>').text(label).appendTo(ul)
   })
+}
+
+function computeStats (hinario) {
+  const tokens = hinario.hinos.reduce((a, h) => {
+    if (h.tokens && h.tokens.pt) return [...a, ...h.tokens.pt]
+    return a
+  }, [])
+  const hymnsCount = hinario.hinos.length
+  const tokenCount = tokens.length
+  const uniqueTokens = new Set(tokens.map(t => t.toLowerCase())).size
+  return { hymnsCount, tokenCount, uniqueTokens }
+}
+
+function updateStats (index) {
+  const stats = computeStats(window.adata.hinarios[index])
+  const div = $('#statsDiv').empty()
+  $('<h3/>').text('Hymnal Stats').appendTo(div)
+  const ul = $('<ul/>').appendTo(div)
+  $('<li/>').text(`Hymns: ${stats.hymnsCount}`).appendTo(ul)
+  $('<li/>').text(`Total words: ${stats.tokenCount}`).appendTo(ul)
+  $('<li/>').text(`Unique words: ${stats.uniqueTokens}`).appendTo(ul)
 }


### PR DESCRIPTION
## Summary
- display hymnal statistics on the site
- compute total/unique word counts and hymn count

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ac7be51908325a875d18d3762fd52