### PR TITLE
Add corpus analysis with author network

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,11 @@
         <button id="fullscreenBtn" title="View wordcloud full screen">&#x26F6;</button>
       </div>
       <div id="similarDiv"></div>
-        <div id="statsDiv"></div>
+      <div id="statsDiv"></div>
+    </div>
+    <div id="corpusContainer">
+      <div id="corpusStats"></div>
+      <div id="authorNetwork"></div>
     </div>
     <div id="wordModal" class="modal">
       <div class="modal-content">
@@ -30,6 +34,7 @@
         <p id="modalWord"></p>
       </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
     <script type="module" src="scripts/bundle.js"></script>
     <input id="file-input" type="file" name="name" style="display: none;" />
 
@@ -107,6 +112,28 @@
 #statsDiv ul {
   list-style-type: none;
   padding-left: 0;
+}
+
+#corpusContainer {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 40px;
+  margin-top: 2%;
+}
+
+#corpusStats {
+  max-width: 300px;
+}
+
+#corpusStats ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+#authorNetwork {
+  max-width: 400px;
 }
 
 #selectDiv select {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,8 +1,11 @@
 console.log('scripts/main.js being executed YAUIASHUDAS')
 const $ = require('jquery')
 const WordCloud = require('wordcloud')
+/* global d3 */
 window.jQuery = $
 let hinarioSets = []
+let corpusStats
+let authorSets
 
 function showWordDetail (item) {
   const [word, count] = item
@@ -67,6 +70,10 @@ $.getJSON('hinos/td.json', function (data) {
 
   window.adata = data
   hinarioSets = data.hinarios.map(h => collectTokenSet(h))
+  corpusStats = computeCorpusStats(data.hinarios)
+  authorSets = computeAuthorSets(data.hinarios)
+  updateCorpusStats()
+  drawAuthorNetwork()
   data.hinarios.forEach((i, count) => {
     const aname = `${i.title} - ${i.person}`
     s.append($('<option/>', { class: 'pres' }).val(count).html(aname))
@@ -381,4 +388,121 @@ function updateStats (index) {
   $('<li/>').text(`Hymns: ${stats.hymnsCount}`).appendTo(ul)
   $('<li/>').text(`Total words: ${stats.tokenCount}`).appendTo(ul)
   $('<li/>').text(`Unique words: ${stats.uniqueTokens}`).appendTo(ul)
+}
+
+function computeCorpusStats (hinarios) {
+  const hymnalCount = hinarios.length
+  const hymns = hinarios.reduce((acc, h) => acc + h.hinos.length, 0)
+  const tokens = hinarios.reduce((a, h) => {
+    return [...a, ...h.hinos.reduce((x, hi) => {
+      if (hi.tokens && hi.tokens.pt) return [...x, ...hi.tokens.pt]
+      return x
+    }, [])]
+  }, [])
+  const tokenCount = tokens.length
+  const uniqueTokens = new Set(tokens.map(t => t.toLowerCase()).filter(t => !stopWords_.includes(t))).size
+  return { hymnalCount, hymns, tokenCount, uniqueTokens }
+}
+
+function updateCorpusStats () {
+  const stats = corpusStats
+  const div = $('#corpusStats').empty()
+  $('<h3/>').text('Corpus Stats').appendTo(div)
+  const ul = $('<ul/>').appendTo(div)
+  $('<li/>').text(`Hymnals: ${stats.hymnalCount}`).appendTo(ul)
+  $('<li/>').text(`Hymns: ${stats.hymns}`).appendTo(ul)
+  $('<li/>').text(`Total words: ${stats.tokenCount}`).appendTo(ul)
+  $('<li/>').text(`Unique words: ${stats.uniqueTokens}`).appendTo(ul)
+}
+
+function computeAuthorSets (hinarios) {
+  const authors = {}
+  hinarios.forEach(h => {
+    const tokens = h.hinos.reduce((a, hi) => {
+      if (hi.tokens && hi.tokens.pt) return [...a, ...hi.tokens.pt]
+      return a
+    }, [])
+    const lower = tokens.map(t => t.toLowerCase()).filter(t => !stopWords_.includes(t))
+    if (!authors[h.person]) authors[h.person] = []
+    authors[h.person] = authors[h.person].concat(lower)
+  })
+  return Object.entries(authors).map(([name, toks]) => [name, new Set(toks)])
+}
+
+function computeAuthorNetwork () {
+  const nodes = authorSets.map(([name], i) => ({ id: i, name }))
+  const links = []
+  for (let i = 0; i < authorSets.length; i++) {
+    for (let j = i + 1; j < authorSets.length; j++) {
+      const s = jaccard(authorSets[i][1], authorSets[j][1])
+      if (s > 0.05) links.push({ source: i, target: j, weight: s })
+    }
+  }
+  return { nodes, links }
+}
+
+function drawAuthorNetwork () {
+  const { nodes, links } = computeAuthorNetwork()
+  const width = 400
+  const height = 300
+  const svg = d3.select('#authorNetwork').empty().append('svg')
+    .attr('width', width)
+    .attr('height', height)
+
+  const simulation = d3.forceSimulation(nodes)
+    .force('link', d3.forceLink(links).distance(80).strength(d => d.weight))
+    .force('charge', d3.forceManyBody().strength(-100))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+
+  const link = svg.append('g')
+    .selectAll('line')
+    .data(links)
+    .enter().append('line')
+    .attr('stroke', '#999')
+    .attr('stroke-width', d => 1 + 4 * d.weight)
+
+  const node = svg.append('g')
+    .selectAll('circle')
+    .data(nodes)
+    .enter().append('circle')
+    .attr('r', 5)
+    .attr('fill', 'steelblue')
+    .call(d3.drag()
+      .on('start', dragstarted)
+      .on('drag', dragged)
+      .on('end', dragended))
+
+  const label = svg.append('g')
+    .selectAll('text')
+    .data(nodes)
+    .enter().append('text')
+    .attr('dy', -8)
+    .attr('font-size', 10)
+    .text(d => d.name)
+
+  simulation.on('tick', () => {
+    link.attr('x1', d => d.source.x)
+      .attr('y1', d => d.source.y)
+      .attr('x2', d => d.target.x)
+      .attr('y2', d => d.target.y)
+    node.attr('cx', d => d.x)
+      .attr('cy', d => d.y)
+    label.attr('x', d => d.x)
+      .attr('y', d => d.y)
+  })
+
+  function dragstarted (event) {
+    if (!event.active) simulation.alphaTarget(0.3).restart()
+    event.subject.fx = event.subject.x
+    event.subject.fy = event.subject.y
+  }
+  function dragged (event) {
+    event.subject.fx = event.x
+    event.subject.fy = event.y
+  }
+  function dragended (event) {
+    if (!event.active) simulation.alphaTarget(0)
+    event.subject.fx = null
+    event.subject.fy = null
+  }
 }


### PR DESCRIPTION
## Summary
- add a corpus analysis pane with global statistics
- show author similarity as a small network using d3
- adjust linting configuration for global d3

## Testing
- `npx standard`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ad0c1c8e08325a1c6fef17fc60a0e