### PR TITLE
Fix d3 author network rendering

### DIFF
--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -12423,7 +12423,7 @@ function drawAuthorNetwork () {
   const { nodes, links } = computeAuthorNetwork()
   const width = 400
   const height = 300
-  const svg = d3.select('#authorNetwork').empty().append('svg')
+  const svg = d3.select('#authorNetwork').html('').append('svg')
     .attr('width', width)
     .attr('height', height)
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -465,7 +465,7 @@ function drawAuthorNetwork () {
   const { nodes, links } = computeAuthorNetwork()
   const width = 400
   const height = 300
-  const svg = d3.select('#authorNetwork').empty().append('svg')
+  const svg = d3.select('#authorNetwork').html('').append('svg')
     .attr('width', width)
     .attr('height', height)
 


### PR DESCRIPTION
## Summary
- clear the `authorNetwork` container properly using d3

## Testing
- `npm run build`
- `npx standard`


------
https://chatgpt.com/codex/tasks/task_e_687ad6af6434832591d05418f2299943