### PR TITLE
Modularize client scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "wordcloud": "^1.2.2"
       },
       "devDependencies": {
+        "esmify": "^2.1.1",
         "standard": "*"
       }
     },
@@ -21,6 +22,363 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+      "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.27.3",
+        "@babel/helpers": "^7.27.6",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/core/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
+      "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+      "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+      "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+      "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
+      "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
+      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.0",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
+      "integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -111,6 +469,45 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -467,6 +864,208 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-code-frame/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "node_modules/babel-plugin-import-to-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-import-to-require/-/babel-plugin-import-to-require-1.0.0.tgz",
+      "integrity": "sha512-dc843CwrFivjO8AVgxcHvxl0cb7J7Ed8ZGFP8+PjH3X1CnyzYtAU1WL1349m9Wc/+oqk4ETx2+cIEO2jlp3XyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-template": "^6.26.0"
+      }
+    },
+    "node_modules/babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "node_modules/babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-traverse/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/babel-traverse/node_modules/globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-traverse/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "node_modules/babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "babylon": "bin/babylon.js"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -688,6 +1287,39 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "license": "MIT"
     },
+    "node_modules/browserslist": {
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001726",
+        "electron-to-chromium": "^1.5.173",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
@@ -802,6 +1434,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001727",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -896,6 +1549,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
       "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg==",
+      "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true,
+      "hasInstallScript": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
@@ -1161,6 +1823,13 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.187",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.187.tgz",
+      "integrity": "sha512-cl5Jc9I0KGUoOoSbxvTywTa40uspGJt/BDBoDLoxJRSBpWh4FFXBsjNRHfQrONsV/OoEjDfHUmZQa2d6Ze4YgA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/elliptic": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
@@ -1345,6 +2014,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1774,6 +2453,25 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esmify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/esmify/-/esmify-2.1.1.tgz",
+      "integrity": "sha512-GyOVgjG7sNyYB5Mbo15Ll4aGrcXZzZ3LI22rbLOjCI7L/wYelzQpBHRZkZkqbPNZ/QIRilcaHqzgNCLcEsi1lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.2.2",
+        "@babel/plugin-syntax-async-generators": "^7.2.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.2.0",
+        "babel-plugin-import-to-require": "^1.0.0",
+        "cached-path-relative": "^1.0.2",
+        "concat-stream": "^1.6.2",
+        "duplexer2": "^0.1.4",
+        "through2": "^2.0.5"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -1988,6 +2686,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-assigned-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
@@ -2144,6 +2852,29 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has-ansi/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
@@ -2383,6 +3114,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-arguments": {
@@ -2764,6 +3505,19 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2911,6 +3665,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.memoize": {
       "version": "3.0.4",
@@ -3064,6 +3825,13 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3406,6 +4174,13 @@
         "inherits": "^2.0.1"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -3694,6 +4469,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
@@ -4398,6 +5180,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -4556,6 +5348,37 @@
       },
       "bin": {
         "undeclared-identifiers": "bin.js"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "da1me",
   "devDependencies": {
+    "esmify": "^2.1.1",
     "standard": "*"
   },
   "scripts": {
-    "build": "npx browserify scripts/main.js > scripts/bundle.js",
+    "build": "npx browserify src/index.js -p esmify > scripts/bundle.js",
     "dev": "nodemon app.js --exec 'standard && npm run build && node'",
     "fixme": "standard --fix"
   },

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -11956,393 +11956,178 @@ if (!window.clearImmediate) {
 })(this) // jshint ignore:line
 
 },{}],3:[function(require,module,exports){
-console.log('scripts/main.js being executed YAUIASHUDAS')
-const $ = require('jquery')
-const WordCloud = require('wordcloud')
-/* global d3 */
-window.jQuery = $
-let hinarioSets = []
-let corpusStats
-let authorSets
+"use strict";
 
-function showWordDetail (item) {
-  const [word, count] = item
-  $('#modalWord').text(`${word} - ${count}x`)
-  $('#wordModal').show()
-}
-
-$(function () {
-  $('#wordModal .close').on('click', () => $('#wordModal').hide())
-  $('#wordModal').on('click', e => {
-    if (e.target.id === 'wordModal') $('#wordModal').hide()
-  })
-  $('#fullscreenBtn').on('click', () => {
-    const doc = document
-    if (!doc.fullscreenElement && !doc.webkitFullscreenElement && !doc.msFullscreenElement) {
-      const elem = document.documentElement
-      if (elem.requestFullscreen) {
-        elem.requestFullscreen()
-      } else if (elem.webkitRequestFullscreen) {
-        elem.webkitRequestFullscreen()
-      } else if (elem.msRequestFullscreen) {
-        elem.msRequestFullscreen()
-      }
-    } else {
-      if (doc.exitFullscreen) {
-        doc.exitFullscreen()
-      } else if (doc.webkitExitFullscreen) {
-        doc.webkitExitFullscreen()
-      } else if (doc.msExitFullscreen) {
-        doc.msExitFullscreen()
-      }
-    }
-  })
-})
-
-// load the JSON file from the hymns
-// plot hymn words according to the selected hymn
-$.getJSON('hinos/td.json', function (data) {
-  $('<label/>', { for: 'mselect' }).html('select hymnal: ').appendTo('#selectDiv')
-  const s = $('<select/>', { id: 'mselect' }).appendTo('#selectDiv')
-    .attr('title', 'Select hymn to analyze.')
-    .on('change', aself => {
-      console.log('hymn changed', aself)
-      const ii = aself.currentTarget.value
-      console.log({ ii })
-      if (ii === '-1') {
-        return
-      }
-      const e = data.hinarios[ii]
-      console.log({ e, data })
-      // fazer análise da:
-      // pessoa
-      // hinário
-      // cada hino
-      plotWordcloud(e)
-      updateSimilarHinarios(Number(ii))
-      updateStats(Number(ii))
-    })
-
-  // const cd = $('<div/>', { id: 'contentDiv' }).appendTo('body')
-  // $('<canvas/>', { id: 'contentCanvas', width: '1000' }).appendTo(cd)
-
-  window.adata = data
-  hinarioSets = data.hinarios.map(h => collectTokenSet(h))
-  corpusStats = computeCorpusStats(data.hinarios)
-  authorSets = computeAuthorSets(data.hinarios)
-  updateCorpusStats()
-  drawAuthorNetwork()
+var _jquery = _interopRequireDefault(require("jquery"));
+var _ui = require("./ui.js");
+var _wordcloud = require("./wordcloud.js");
+var _stats = require("./stats.js");
+var _network = require("./network.js");
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+window.jQuery = _jquery.default;
+(0, _ui.setupUI)();
+let hinarioSets = [];
+let corpusStats;
+let authorSets;
+_jquery.default.getJSON('hinos/td.json', function (data) {
+  (0, _jquery.default)('<label/>', {
+    for: 'mselect'
+  }).html('select hymnal: ').appendTo('#selectDiv');
+  const s = (0, _jquery.default)('<select/>', {
+    id: 'mselect'
+  }).appendTo('#selectDiv').attr('title', 'Select hymn to analyze.').on('change', aself => {
+    const ii = aself.currentTarget.value;
+    if (ii === '-1') return;
+    const e = data.hinarios[ii];
+    (0, _wordcloud.plotWordcloud)(e);
+    (0, _stats.updateSimilarHinarios)(Number(ii), hinarioSets, data.hinarios);
+    (0, _stats.updateStats)(e);
+  });
+  window.adata = data;
+  hinarioSets = data.hinarios.map(h => (0, _stats.collectTokenSet)(h));
+  corpusStats = (0, _stats.computeCorpusStats)(data.hinarios);
+  authorSets = (0, _stats.computeAuthorSets)(data.hinarios);
+  (0, _stats.updateCorpusStats)(corpusStats);
+  (0, _network.drawAuthorNetwork)(authorSets);
   data.hinarios.forEach((i, count) => {
-    const aname = `${i.title} - ${i.person}`
-    s.append($('<option/>', { class: 'pres' }).val(count).html(aname))
-    $('#loading').hide()
-  })
-  plotWordcloud(data.hinarios[0])
-  updateSimilarHinarios(0)
-  updateStats(0)
-})
+    const aname = `${i.title} - ${i.person}`;
+    s.append((0, _jquery.default)('<option/>', {
+      class: 'pres'
+    }).val(count).html(aname));
+    (0, _jquery.default)('#loading').hide();
+  });
+  (0, _wordcloud.plotWordcloud)(data.hinarios[0]);
+  (0, _stats.updateSimilarHinarios)(0, hinarioSets, data.hinarios);
+  (0, _stats.updateStats)(data.hinarios[0]);
+});
 
-function plotWordcloud (hinario) {
-  function getTokens (tokens) {
-    if ('pt' in tokens) {
-      return tokens.pt
+},{"./network.js":4,"./stats.js":5,"./ui.js":6,"./wordcloud.js":7,"jquery":1}],4:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.computeAuthorNetwork = computeAuthorNetwork;
+exports.computeAuthorSets = computeAuthorSets;
+exports.drawAuthorNetwork = drawAuthorNetwork;
+var _stats = require("./stats.js");
+/* global d3 */
+
+function computeAuthorSets(hinarios) {
+  const authors = {};
+  hinarios.forEach(h => {
+    const tokens = h.hinos.reduce((a, hi) => {
+      if (hi.tokens && hi.tokens.pt) return [...a, ...hi.tokens.pt];
+      return a;
+    }, []);
+    const lower = tokens.map(t => t.toLowerCase()).filter(t => !_stats.stopWords_.includes(t));
+    if (!authors[h.person]) authors[h.person] = [];
+    authors[h.person] = authors[h.person].concat(lower);
+  });
+  return Object.entries(authors).map(([name, toks]) => [name, new Set(toks)]);
+}
+function computeAuthorNetwork(authorSets) {
+  const nodes = authorSets.map(([name], i) => ({
+    id: i,
+    name
+  }));
+  const links = [];
+  for (let i = 0; i < authorSets.length; i++) {
+    for (let j = i + 1; j < authorSets.length; j++) {
+      const s = (0, _stats.jaccard)(authorSets[i][1], authorSets[j][1]);
+      if (s > 0.05) links.push({
+        source: i,
+        target: j,
+        weight: s
+      });
     }
-    return []
   }
-  const tokens = hinario.hinos.reduce((a, h) => [...a, ...getTokens(h.tokens)], [])
-  console.log({ tokens })
-  window.tt = tokens
-  const tokensLower = tokens.map(t => t.toLowerCase())
-  const tokensSet = [...new Set(tokensLower)].filter(t => !stopWords_.includes(t))
-  const tokensHist = tokensSet.map(t => {
-    const count = tokensLower.filter(tt => t === tt).length
-    return { t, count }
-  })
-  tokensHist.sort((a, b) => a.count > b.count ? -1 : 1)
-  // const items = tokensHist.map((t, i) => {
-  //   return `<li>(${i}) ${t.t} - ${t.count}x</li>`
-  // })
-  // $('<ul/>', {
-  //   class: 'my-new-list',
-  //   html: items.join('')
-  // }).appendTo('#contentDiv')
-  const list = tokensHist.map(i => [i.t, i.count])
-  WordCloud(document.getElementById('contentCanvas'), {
-    list,
-    weightFactor: 100 / tokensHist[0].count,
-    click: showWordDetail
-  })
-
-  window.th = { tokensHist, list }
+  return {
+    nodes,
+    links
+  };
+}
+function drawAuthorNetwork(authorSets) {
+  const {
+    nodes,
+    links
+  } = computeAuthorNetwork(authorSets);
+  const width = 400;
+  const height = 300;
+  const svg = d3.select('#authorNetwork').html('').append('svg').attr('width', width).attr('height', height);
+  const simulation = d3.forceSimulation(nodes).force('link', d3.forceLink(links).distance(80).strength(d => d.weight)).force('charge', d3.forceManyBody().strength(-100)).force('center', d3.forceCenter(width / 2, height / 2));
+  const link = svg.append('g').selectAll('line').data(links).enter().append('line').attr('stroke', '#999').attr('stroke-width', d => 1 + 4 * d.weight);
+  const node = svg.append('g').selectAll('circle').data(nodes).enter().append('circle').attr('r', 5).attr('fill', 'steelblue').call(d3.drag().on('start', dragstarted).on('drag', dragged).on('end', dragended));
+  const label = svg.append('g').selectAll('text').data(nodes).enter().append('text').attr('dy', -8).attr('font-size', 10).text(d => d.name);
+  simulation.on('tick', () => {
+    link.attr('x1', d => d.source.x).attr('y1', d => d.source.y).attr('x2', d => d.target.x).attr('y2', d => d.target.y);
+    node.attr('cx', d => d.x).attr('cy', d => d.y);
+    label.attr('x', d => d.x).attr('y', d => d.y);
+  });
+  function dragstarted(event) {
+    if (!event.active) simulation.alphaTarget(0.3).restart();
+    event.subject.fx = event.subject.x;
+    event.subject.fy = event.subject.y;
+  }
+  function dragged(event) {
+    event.subject.fx = event.x;
+    event.subject.fy = event.y;
+  }
+  function dragended(event) {
+    if (!event.active) simulation.alphaTarget(0);
+    event.subject.fx = null;
+    event.subject.fy = null;
+  }
 }
 
-const stopWords = [
-  'a',
-  'à',
-  'ao',
-  'aos',
-  'aquela',
-  'aquelas',
-  'aquele',
-  'aqueles',
-  'aquilo',
-  'as',
-  'às',
-  'até',
-  'com',
-  'como',
-  'da',
-  'das',
-  'de',
-  'dela',
-  'delas',
-  'dele',
-  'deles',
-  'depois',
-  'do',
-  'dos',
-  'e',
-  'é',
-  'ela',
-  'elas',
-  'ele',
-  'eles',
-  'em',
-  'entre',
-  'era',
-  'eram',
-  'éramos',
-  'essa',
-  'essas',
-  'esse',
-  'esses',
-  'esta',
-  'está',
-  'estamos',
-  'estão',
-  'estar',
-  'estas',
-  'estava',
-  'estavam',
-  'estávamos',
-  'este',
-  'esteja',
-  'estejam',
-  'estejamos',
-  'estes',
-  'esteve',
-  'estive',
-  'estivemos',
-  'estiver',
-  'estivera',
-  'estiveram',
-  'estivéramos',
-  'estiverem',
-  'estivermos',
-  'estivesse',
-  'estivessem',
-  'estivéssemos',
-  'estou',
-  'eu',
-  'foi',
-  'fomos',
-  'for',
-  'fora',
-  'foram',
-  'fôramos',
-  'forem',
-  'formos',
-  'fosse',
-  'fossem',
-  'fôssemos',
-  'fui',
-  'há',
-  'haja',
-  'hajam',
-  'hajamos',
-  'hão',
-  'havemos',
-  'haver',
-  'hei',
-  'houve',
-  'houvemos',
-  'houver',
-  'houvera',
-  'houverá',
-  'houveram',
-  'houvéramos',
-  'houverão',
-  'houverei',
-  'houverem',
-  'houveremos',
-  'houveria',
-  'houveriam',
-  'houveríamos',
-  'houvermos',
-  'houvesse',
-  'houvessem',
-  'houvéssemos',
-  'isso',
-  'isto',
-  'já',
-  'lhe',
-  'lhes',
-  'mais',
-  'mas',
-  'me',
-  'mesmo',
-  'meu',
-  'meus',
-  'minha',
-  'minhas',
-  'muito',
-  'na',
-  'não',
-  'nas',
-  'nem',
-  'no',
-  'nos',
-  'nós',
-  'nossa',
-  'nossas',
-  'nosso',
-  'nossos',
-  'num',
-  'numa',
-  'o',
-  'os',
-  'ou',
-  'para',
-  'pela',
-  'pelas',
-  'pelo',
-  'pelos',
-  'por',
-  'qual',
-  'quando',
-  'que',
-  'quem',
-  'são',
-  'se',
-  'seja',
-  'sejam',
-  'sejamos',
-  'sem',
-  'ser',
-  'será',
-  'serão',
-  'serei',
-  'seremos',
-  'seria',
-  'seriam',
-  'seríamos',
-  'seu',
-  'seus',
-  'só',
-  'somos',
-  'sou',
-  'sua',
-  'suas',
-  'também',
-  'te',
-  'tem',
-  'tém',
-  'temos',
-  'tenha',
-  'tenham',
-  'tenhamos',
-  'tenho',
-  'terá',
-  'terão',
-  'terei',
-  'teremos',
-  'teria',
-  'teriam',
-  'teríamos',
-  'teu',
-  'teus',
-  'teve',
-  'tinha',
-  'tinham',
-  'tínhamos',
-  'tive',
-  'tivemos',
-  'tiver',
-  'tivera',
-  'tiveram',
-  'tivéramos',
-  'tiverem',
-  'tivermos',
-  'tivesse',
-  'tivessem',
-  'tivéssemos',
-  'tu',
-  'tua',
-  'tuas',
-  'um',
-  'uma',
-  'você',
-  'vocês',
-  'vos'
-]
+},{"./stats.js":5}],5:[function(require,module,exports){
+"use strict";
 
-const punct = [
-  ',',
-  '"',
-  "'",
-  '.',
-  '!'
-]
-
-const stopWords_ = [...stopWords, ...punct]
-
-function collectTokenSet (hinario) {
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.collectTokenSet = collectTokenSet;
+exports.computeCorpusStats = computeCorpusStats;
+exports.computeStats = computeStats;
+exports.jaccard = jaccard;
+exports.stopWords_ = exports.stopWords = exports.punct = void 0;
+exports.updateCorpusStats = updateCorpusStats;
+exports.updateSimilarHinarios = updateSimilarHinarios;
+exports.updateStats = updateStats;
+var _jquery = _interopRequireDefault(require("jquery"));
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+const stopWords = exports.stopWords = ['a', 'à', 'ao', 'aos', 'aquela', 'aquelas', 'aquele', 'aqueles', 'aquilo', 'as', 'às', 'até', 'com', 'como', 'da', 'das', 'de', 'dela', 'delas', 'dele', 'deles', 'depois', 'do', 'dos', 'e', 'é', 'ela', 'elas', 'ele', 'eles', 'em', 'entre', 'era', 'eram', 'éramos', 'essa', 'essas', 'esse', 'esses', 'esta', 'está', 'estamos', 'estão', 'estar', 'estas', 'estava', 'estavam', 'estávamos', 'este', 'esteja', 'estejam', 'estejamos', 'estes', 'esteve', 'estive', 'estivemos', 'estiver', 'estivera', 'estiveram', 'estivéramos', 'estiverem', 'estivermos', 'estivesse', 'estivessem', 'estivéssemos', 'estou', 'eu', 'foi', 'fomos', 'for', 'fora', 'foram', 'fôramos', 'forem', 'formos', 'fosse', 'fossem', 'fôssemos', 'fui', 'há', 'haja', 'hajam', 'hajamos', 'hão', 'havemos', 'haver', 'hei', 'houve', 'houvemos', 'houver', 'houvera', 'houverá', 'houveram', 'houvéramos', 'houverão', 'houverei', 'houverem', 'houveremos', 'houveria', 'houveriam', 'houveríamos', 'houvermos', 'houvesse', 'houvessem', 'houvéssemos', 'isso', 'isto', 'já', 'lhe', 'lhes', 'mais', 'mas', 'me', 'mesmo', 'meu', 'meus', 'minha', 'minhas', 'muito', 'na', 'não', 'nas', 'nem', 'no', 'nos', 'nós', 'nossa', 'nossas', 'nosso', 'nossos', 'num', 'numa', 'o', 'os', 'ou', 'para', 'pela', 'pelas', 'pelo', 'pelos', 'por', 'qual', 'quando', 'que', 'quem', 'são', 'se', 'seja', 'sejam', 'sejamos', 'sem', 'ser', 'será', 'serão', 'serei', 'seremos', 'seria', 'seriam', 'seríamos', 'seu', 'seus', 'só', 'somos', 'sou', 'sua', 'suas', 'também', 'te', 'tem', 'tém', 'temos', 'tenha', 'tenham', 'tenhamos', 'tenho', 'terá', 'terão', 'terei', 'teremos', 'teria', 'teriam', 'teríamos', 'teu', 'teus', 'teve', 'tinha', 'tinham', 'tínhamos', 'tive', 'tivemos', 'tiver', 'tivera', 'tiveram', 'tivéramos', 'tiverem', 'tivermos', 'tivesse', 'tivessem', 'tivéssemos', 'tu', 'tua', 'tuas', 'um', 'uma', 'você', 'vocês', 'vos'];
+const punct = exports.punct = [',', '"', "'", '.', '!'];
+const stopWords_ = exports.stopWords_ = [...stopWords, ...punct];
+function collectTokenSet(hinario) {
   const tokens = hinario.hinos.reduce((a, h) => {
-    if (h.tokens && h.tokens.pt) return [...a, ...h.tokens.pt]
-    return a
-  }, [])
-  const lower = tokens.map(t => t.toLowerCase())
-  return new Set(lower.filter(t => !stopWords_.includes(t)))
+    if (h.tokens && h.tokens.pt) return [...a, ...h.tokens.pt];
+    return a;
+  }, []);
+  const lower = tokens.map(t => t.toLowerCase());
+  return new Set(lower.filter(t => !stopWords_.includes(t)));
 }
-
-function jaccard (setA, setB) {
-  const inter = [...setA].filter(x => setB.has(x))
-  const union = new Set([...setA, ...setB])
-  return inter.length / union.size
+function jaccard(setA, setB) {
+  const inter = [...setA].filter(x => setB.has(x));
+  const union = new Set([...setA, ...setB]);
+  return inter.length / union.size;
 }
-
-function updateSimilarHinarios (index) {
-  const base = hinarioSets[index]
-  const sims = hinarioSets.map((set, i) => {
-    if (i === index) return null
-    return { i, s: jaccard(base, set) }
-  }).filter(Boolean).sort((a, b) => b.s - a.s).slice(0, 3)
-  const div = $('#similarDiv').empty()
-  $('<h3/>').text('Similar Hymnals').appendTo(div)
-  const ul = $('<ul/>').appendTo(div)
-  sims.forEach(m => {
-    const h = window.adata.hinarios[m.i]
-    const label = `${h.title} - ${h.person} (${m.s.toFixed(2)})`
-    $('<li/>').text(label).appendTo(ul)
-  })
-}
-
-function computeStats (hinario) {
+function computeStats(hinario) {
   const hymnTokenCounts = hinario.hinos.map(h => {
-    if (h.tokens && h.tokens.pt) return h.tokens.pt.length
-    return 0
-  })
+    if (h.tokens && h.tokens.pt) return h.tokens.pt.length;
+    return 0;
+  });
   const tokens = hinario.hinos.reduce((a, h) => {
-    if (h.tokens && h.tokens.pt) return [...a, ...h.tokens.pt]
-    return a
-  }, [])
-  const hymnsCount = hinario.hinos.length
-  const tokenCount = tokens.length
-  const uniqueTokens = new Set(tokens.map(t => t.toLowerCase()))
-  const avgTokensPerHymn = hymnsCount ? tokenCount / hymnsCount : 0
-  const uniqueTokenRatio = tokenCount ? uniqueTokens.size / tokenCount : 0
-  const longestHymn = hymnTokenCounts.length ? Math.max(...hymnTokenCounts) : 0
-  const shortestHymn = hymnTokenCounts.length ? Math.min(...hymnTokenCounts) : 0
+    if (h.tokens && h.tokens.pt) return [...a, ...h.tokens.pt];
+    return a;
+  }, []);
+  const hymnsCount = hinario.hinos.length;
+  const tokenCount = tokens.length;
+  const uniqueTokens = new Set(tokens.map(t => t.toLowerCase()));
+  const avgTokensPerHymn = hymnsCount ? tokenCount / hymnsCount : 0;
+  const uniqueTokenRatio = tokenCount ? uniqueTokens.size / tokenCount : 0;
+  const longestHymn = hymnTokenCounts.length ? Math.max(...hymnTokenCounts) : 0;
+  const shortestHymn = hymnTokenCounts.length ? Math.min(...hymnTokenCounts) : 0;
   return {
     hymnsCount,
     tokenCount,
@@ -12351,138 +12136,151 @@ function computeStats (hinario) {
     uniqueTokenRatio,
     longestHymn,
     shortestHymn
-  }
+  };
 }
-
-function updateStats (index) {
-  const stats = computeStats(window.adata.hinarios[index])
-  const div = $('#statsDiv').empty()
-  $('<h3/>').text('Hymnal Stats').appendTo(div)
-  const ul = $('<ul/>').appendTo(div)
-  $('<li/>').text(`Hymns: ${stats.hymnsCount}`).appendTo(ul)
-  $('<li/>').text(`Total words: ${stats.tokenCount}`).appendTo(ul)
-  $('<li/>').text(`Unique words: ${stats.uniqueTokens}`).appendTo(ul)
-  $('<li/>').text(`Avg words/hymn: ${stats.avgTokensPerHymn.toFixed(2)}`).appendTo(ul)
-  $('<li/>').text(`Unique/word ratio: ${stats.uniqueTokenRatio.toFixed(2)}`).appendTo(ul)
-  $('<li/>').text(`Longest hymn: ${stats.longestHymn} words`).appendTo(ul)
-  $('<li/>').text(`Shortest hymn: ${stats.shortestHymn} words`).appendTo(ul)
+function updateStats(hinario) {
+  const stats = computeStats(hinario);
+  const div = (0, _jquery.default)('#statsDiv').empty();
+  (0, _jquery.default)('<h3/>').text('Hymnal Stats').appendTo(div);
+  const ul = (0, _jquery.default)('<ul/>').appendTo(div);
+  (0, _jquery.default)('<li/>').text(`Hymns: ${stats.hymnsCount}`).appendTo(ul);
+  (0, _jquery.default)('<li/>').text(`Total words: ${stats.tokenCount}`).appendTo(ul);
+  (0, _jquery.default)('<li/>').text(`Unique words: ${stats.uniqueTokens}`).appendTo(ul);
+  (0, _jquery.default)('<li/>').text(`Avg words/hymn: ${stats.avgTokensPerHymn.toFixed(2)}`).appendTo(ul);
+  (0, _jquery.default)('<li/>').text(`Unique/word ratio: ${stats.uniqueTokenRatio.toFixed(2)}`).appendTo(ul);
+  (0, _jquery.default)('<li/>').text(`Longest hymn: ${stats.longestHymn} words`).appendTo(ul);
+  (0, _jquery.default)('<li/>').text(`Shortest hymn: ${stats.shortestHymn} words`).appendTo(ul);
 }
-
-function computeCorpusStats (hinarios) {
-  const hymnalCount = hinarios.length
-  const hymns = hinarios.reduce((acc, h) => acc + h.hinos.length, 0)
+function computeCorpusStats(hinarios) {
+  const hymnalCount = hinarios.length;
+  const hymns = hinarios.reduce((acc, h) => acc + h.hinos.length, 0);
   const tokens = hinarios.reduce((a, h) => {
     return [...a, ...h.hinos.reduce((x, hi) => {
-      if (hi.tokens && hi.tokens.pt) return [...x, ...hi.tokens.pt]
-      return x
-    }, [])]
-  }, [])
-  const tokenCount = tokens.length
-  const uniqueTokens = new Set(tokens.map(t => t.toLowerCase()).filter(t => !stopWords_.includes(t))).size
-  return { hymnalCount, hymns, tokenCount, uniqueTokens }
+      if (hi.tokens && hi.tokens.pt) return [...x, ...hi.tokens.pt];
+      return x;
+    }, [])];
+  }, []);
+  const tokenCount = tokens.length;
+  const uniqueTokens = new Set(tokens.map(t => t.toLowerCase()).filter(t => !stopWords_.includes(t))).size;
+  return {
+    hymnalCount,
+    hymns,
+    tokenCount,
+    uniqueTokens
+  };
+}
+function updateCorpusStats(stats) {
+  const div = (0, _jquery.default)('#corpusStats').empty();
+  (0, _jquery.default)('<h3/>').text('Corpus Stats').appendTo(div);
+  const ul = (0, _jquery.default)('<ul/>').appendTo(div);
+  (0, _jquery.default)('<li/>').text(`Hymnals: ${stats.hymnalCount}`).appendTo(ul);
+  (0, _jquery.default)('<li/>').text(`Hymns: ${stats.hymns}`).appendTo(ul);
+  (0, _jquery.default)('<li/>').text(`Total words: ${stats.tokenCount}`).appendTo(ul);
+  (0, _jquery.default)('<li/>').text(`Unique words: ${stats.uniqueTokens}`).appendTo(ul);
+}
+function updateSimilarHinarios(index, hinarioSets, hinarios) {
+  const base = hinarioSets[index];
+  const sims = hinarioSets.map((set, i) => {
+    if (i === index) return null;
+    return {
+      i,
+      s: jaccard(base, set)
+    };
+  }).filter(Boolean).sort((a, b) => b.s - a.s).slice(0, 3);
+  const div = (0, _jquery.default)('#similarDiv').empty();
+  (0, _jquery.default)('<h3/>').text('Similar Hymnals').appendTo(div);
+  const ul = (0, _jquery.default)('<ul/>').appendTo(div);
+  sims.forEach(m => {
+    const h = hinarios[m.i];
+    const label = `${h.title} - ${h.person} (${m.s.toFixed(2)})`;
+    (0, _jquery.default)('<li/>').text(label).appendTo(ul);
+  });
 }
 
-function updateCorpusStats () {
-  const stats = corpusStats
-  const div = $('#corpusStats').empty()
-  $('<h3/>').text('Corpus Stats').appendTo(div)
-  const ul = $('<ul/>').appendTo(div)
-  $('<li/>').text(`Hymnals: ${stats.hymnalCount}`).appendTo(ul)
-  $('<li/>').text(`Hymns: ${stats.hymns}`).appendTo(ul)
-  $('<li/>').text(`Total words: ${stats.tokenCount}`).appendTo(ul)
-  $('<li/>').text(`Unique words: ${stats.uniqueTokens}`).appendTo(ul)
+},{"jquery":1}],6:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.setupUI = setupUI;
+exports.showWordDetail = showWordDetail;
+var _jquery = _interopRequireDefault(require("jquery"));
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+function showWordDetail(item) {
+  const [word, count] = item;
+  (0, _jquery.default)('#modalWord').text(`${word} - ${count}x`);
+  (0, _jquery.default)('#wordModal').show();
+}
+function setupUI() {
+  (0, _jquery.default)(function () {
+    (0, _jquery.default)('#wordModal .close').on('click', () => (0, _jquery.default)('#wordModal').hide());
+    (0, _jquery.default)('#wordModal').on('click', e => {
+      if (e.target.id === 'wordModal') (0, _jquery.default)('#wordModal').hide();
+    });
+    (0, _jquery.default)('#fullscreenBtn').on('click', () => {
+      const doc = document;
+      if (!doc.fullscreenElement && !doc.webkitFullscreenElement && !doc.msFullscreenElement) {
+        const elem = document.documentElement;
+        if (elem.requestFullscreen) {
+          elem.requestFullscreen();
+        } else if (elem.webkitRequestFullscreen) {
+          elem.webkitRequestFullscreen();
+        } else if (elem.msRequestFullscreen) {
+          elem.msRequestFullscreen();
+        }
+      } else {
+        if (doc.exitFullscreen) {
+          doc.exitFullscreen();
+        } else if (doc.webkitExitFullscreen) {
+          doc.webkitExitFullscreen();
+        } else if (doc.msExitFullscreen) {
+          doc.msExitFullscreen();
+        }
+      }
+    });
+  });
 }
 
-function computeAuthorSets (hinarios) {
-  const authors = {}
-  hinarios.forEach(h => {
-    const tokens = h.hinos.reduce((a, hi) => {
-      if (hi.tokens && hi.tokens.pt) return [...a, ...hi.tokens.pt]
-      return a
-    }, [])
-    const lower = tokens.map(t => t.toLowerCase()).filter(t => !stopWords_.includes(t))
-    if (!authors[h.person]) authors[h.person] = []
-    authors[h.person] = authors[h.person].concat(lower)
-  })
-  return Object.entries(authors).map(([name, toks]) => [name, new Set(toks)])
-}
+},{"jquery":1}],7:[function(require,module,exports){
+"use strict";
 
-function computeAuthorNetwork () {
-  const nodes = authorSets.map(([name], i) => ({ id: i, name }))
-  const links = []
-  for (let i = 0; i < authorSets.length; i++) {
-    for (let j = i + 1; j < authorSets.length; j++) {
-      const s = jaccard(authorSets[i][1], authorSets[j][1])
-      if (s > 0.05) links.push({ source: i, target: j, weight: s })
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.plotWordcloud = plotWordcloud;
+var _wordcloud = _interopRequireDefault(require("wordcloud"));
+var _stats = require("./stats.js");
+var _ui = require("./ui.js");
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+function plotWordcloud(hinario) {
+  function getTokens(tokens) {
+    if (tokens && 'pt' in tokens) {
+      return tokens.pt;
     }
+    return [];
   }
-  return { nodes, links }
+  const tokens = hinario.hinos.reduce((a, h) => [...a, ...getTokens(h.tokens)], []);
+  const tokensLower = tokens.map(t => t.toLowerCase());
+  const tokensSet = [...new Set(tokensLower)].filter(t => !_stats.stopWords_.includes(t));
+  const tokensHist = tokensSet.map(t => {
+    const count = tokensLower.filter(tt => t === tt).length;
+    return {
+      t,
+      count
+    };
+  });
+  tokensHist.sort((a, b) => a.count > b.count ? -1 : 1);
+  const list = tokensHist.map(i => [i.t, i.count]);
+  (0, _wordcloud.default)(document.getElementById('contentCanvas'), {
+    list,
+    weightFactor: 100 / tokensHist[0].count,
+    click: _ui.showWordDetail
+  });
+  window.th = {
+    tokensHist,
+    list
+  };
 }
 
-function drawAuthorNetwork () {
-  const { nodes, links } = computeAuthorNetwork()
-  const width = 400
-  const height = 300
-  const svg = d3.select('#authorNetwork').html('').append('svg')
-    .attr('width', width)
-    .attr('height', height)
-
-  const simulation = d3.forceSimulation(nodes)
-    .force('link', d3.forceLink(links).distance(80).strength(d => d.weight))
-    .force('charge', d3.forceManyBody().strength(-100))
-    .force('center', d3.forceCenter(width / 2, height / 2))
-
-  const link = svg.append('g')
-    .selectAll('line')
-    .data(links)
-    .enter().append('line')
-    .attr('stroke', '#999')
-    .attr('stroke-width', d => 1 + 4 * d.weight)
-
-  const node = svg.append('g')
-    .selectAll('circle')
-    .data(nodes)
-    .enter().append('circle')
-    .attr('r', 5)
-    .attr('fill', 'steelblue')
-    .call(d3.drag()
-      .on('start', dragstarted)
-      .on('drag', dragged)
-      .on('end', dragended))
-
-  const label = svg.append('g')
-    .selectAll('text')
-    .data(nodes)
-    .enter().append('text')
-    .attr('dy', -8)
-    .attr('font-size', 10)
-    .text(d => d.name)
-
-  simulation.on('tick', () => {
-    link.attr('x1', d => d.source.x)
-      .attr('y1', d => d.source.y)
-      .attr('x2', d => d.target.x)
-      .attr('y2', d => d.target.y)
-    node.attr('cx', d => d.x)
-      .attr('cy', d => d.y)
-    label.attr('x', d => d.x)
-      .attr('y', d => d.y)
-  })
-
-  function dragstarted (event) {
-    if (!event.active) simulation.alphaTarget(0.3).restart()
-    event.subject.fx = event.subject.x
-    event.subject.fy = event.subject.y
-  }
-  function dragged (event) {
-    event.subject.fx = event.x
-    event.subject.fy = event.y
-  }
-  function dragended (event) {
-    if (!event.active) simulation.alphaTarget(0)
-    event.subject.fx = null
-    event.subject.fy = null
-  }
-}
-
-},{"jquery":1,"wordcloud":2}]},{},[3]);
+},{"./stats.js":5,"./ui.js":6,"wordcloud":2}]},{},[3]);

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,49 @@
+import $ from 'jquery'
+import { setupUI } from './ui.js'
+import { plotWordcloud } from './wordcloud.js'
+import {
+  collectTokenSet,
+  computeCorpusStats,
+  computeAuthorSets,
+  updateCorpusStats,
+  updateStats,
+  updateSimilarHinarios
+} from './stats.js'
+import { drawAuthorNetwork } from './network.js'
+
+window.jQuery = $
+
+setupUI()
+
+let hinarioSets = []
+let corpusStats
+let authorSets
+
+$.getJSON('hinos/td.json', function (data) {
+  $('<label/>', { for: 'mselect' }).html('select hymnal: ').appendTo('#selectDiv')
+  const s = $('<select/>', { id: 'mselect' }).appendTo('#selectDiv')
+    .attr('title', 'Select hymn to analyze.')
+    .on('change', aself => {
+      const ii = aself.currentTarget.value
+      if (ii === '-1') return
+      const e = data.hinarios[ii]
+      plotWordcloud(e)
+      updateSimilarHinarios(Number(ii), hinarioSets, data.hinarios)
+      updateStats(e)
+    })
+
+  window.adata = data
+  hinarioSets = data.hinarios.map(h => collectTokenSet(h))
+  corpusStats = computeCorpusStats(data.hinarios)
+  authorSets = computeAuthorSets(data.hinarios)
+  updateCorpusStats(corpusStats)
+  drawAuthorNetwork(authorSets)
+  data.hinarios.forEach((i, count) => {
+    const aname = `${i.title} - ${i.person}`
+    s.append($('<option/>', { class: 'pres' }).val(count).html(aname))
+    $('#loading').hide()
+  })
+  plotWordcloud(data.hinarios[0])
+  updateSimilarHinarios(0, hinarioSets, data.hinarios)
+  updateStats(data.hinarios[0])
+})

--- a/src/network.js
+++ b/src/network.js
@@ -1,0 +1,94 @@
+import { jaccard, stopWords_ } from './stats.js'
+/* global d3 */
+
+export function computeAuthorSets (hinarios) {
+  const authors = {}
+  hinarios.forEach(h => {
+    const tokens = h.hinos.reduce((a, hi) => {
+      if (hi.tokens && hi.tokens.pt) return [...a, ...hi.tokens.pt]
+      return a
+    }, [])
+    const lower = tokens.map(t => t.toLowerCase()).filter(t => !stopWords_.includes(t))
+    if (!authors[h.person]) authors[h.person] = []
+    authors[h.person] = authors[h.person].concat(lower)
+  })
+  return Object.entries(authors).map(([name, toks]) => [name, new Set(toks)])
+}
+
+export function computeAuthorNetwork (authorSets) {
+  const nodes = authorSets.map(([name], i) => ({ id: i, name }))
+  const links = []
+  for (let i = 0; i < authorSets.length; i++) {
+    for (let j = i + 1; j < authorSets.length; j++) {
+      const s = jaccard(authorSets[i][1], authorSets[j][1])
+      if (s > 0.05) links.push({ source: i, target: j, weight: s })
+    }
+  }
+  return { nodes, links }
+}
+
+export function drawAuthorNetwork (authorSets) {
+  const { nodes, links } = computeAuthorNetwork(authorSets)
+  const width = 400
+  const height = 300
+  const svg = d3.select('#authorNetwork').html('').append('svg')
+    .attr('width', width)
+    .attr('height', height)
+
+  const simulation = d3.forceSimulation(nodes)
+    .force('link', d3.forceLink(links).distance(80).strength(d => d.weight))
+    .force('charge', d3.forceManyBody().strength(-100))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+
+  const link = svg.append('g')
+    .selectAll('line')
+    .data(links)
+    .enter().append('line')
+    .attr('stroke', '#999')
+    .attr('stroke-width', d => 1 + 4 * d.weight)
+
+  const node = svg.append('g')
+    .selectAll('circle')
+    .data(nodes)
+    .enter().append('circle')
+    .attr('r', 5)
+    .attr('fill', 'steelblue')
+    .call(d3.drag()
+      .on('start', dragstarted)
+      .on('drag', dragged)
+      .on('end', dragended))
+
+  const label = svg.append('g')
+    .selectAll('text')
+    .data(nodes)
+    .enter().append('text')
+    .attr('dy', -8)
+    .attr('font-size', 10)
+    .text(d => d.name)
+
+  simulation.on('tick', () => {
+    link.attr('x1', d => d.source.x)
+      .attr('y1', d => d.source.y)
+      .attr('x2', d => d.target.x)
+      .attr('y2', d => d.target.y)
+    node.attr('cx', d => d.x)
+      .attr('cy', d => d.y)
+    label.attr('x', d => d.x)
+      .attr('y', d => d.y)
+  })
+
+  function dragstarted (event) {
+    if (!event.active) simulation.alphaTarget(0.3).restart()
+    event.subject.fx = event.subject.x
+    event.subject.fy = event.subject.y
+  }
+  function dragged (event) {
+    event.subject.fx = event.x
+    event.subject.fy = event.y
+  }
+  function dragended (event) {
+    if (!event.active) simulation.alphaTarget(0)
+    event.subject.fx = null
+    event.subject.fy = null
+  }
+}

--- a/src/stats.js
+++ b/src/stats.js
@@ -1,0 +1,128 @@
+import $ from 'jquery'
+
+export const stopWords = [
+  'a', 'à', 'ao', 'aos', 'aquela', 'aquelas', 'aquele', 'aqueles', 'aquilo',
+  'as', 'às', 'até', 'com', 'como', 'da', 'das', 'de', 'dela', 'delas', 'dele',
+  'deles', 'depois', 'do', 'dos', 'e', 'é', 'ela', 'elas', 'ele', 'eles', 'em',
+  'entre', 'era', 'eram', 'éramos', 'essa', 'essas', 'esse', 'esses', 'esta',
+  'está', 'estamos', 'estão', 'estar', 'estas', 'estava', 'estavam', 'estávamos',
+  'este', 'esteja', 'estejam', 'estejamos', 'estes', 'esteve', 'estive',
+  'estivemos', 'estiver', 'estivera', 'estiveram', 'estivéramos', 'estiverem',
+  'estivermos', 'estivesse', 'estivessem', 'estivéssemos', 'estou', 'eu', 'foi',
+  'fomos', 'for', 'fora', 'foram', 'fôramos', 'forem', 'formos', 'fosse',
+  'fossem', 'fôssemos', 'fui', 'há', 'haja', 'hajam', 'hajamos', 'hão',
+  'havemos', 'haver', 'hei', 'houve', 'houvemos', 'houver', 'houvera',
+  'houverá', 'houveram', 'houvéramos', 'houverão', 'houverei', 'houverem',
+  'houveremos', 'houveria', 'houveriam', 'houveríamos', 'houvermos', 'houvesse',
+  'houvessem', 'houvéssemos', 'isso', 'isto', 'já', 'lhe', 'lhes', 'mais', 'mas',
+  'me', 'mesmo', 'meu', 'meus', 'minha', 'minhas', 'muito', 'na', 'não', 'nas',
+  'nem', 'no', 'nos', 'nós', 'nossa', 'nossas', 'nosso', 'nossos', 'num', 'numa',
+  'o', 'os', 'ou', 'para', 'pela', 'pelas', 'pelo', 'pelos', 'por', 'qual',
+  'quando', 'que', 'quem', 'são', 'se', 'seja', 'sejam', 'sejamos', 'sem', 'ser',
+  'será', 'serão', 'serei', 'seremos', 'seria', 'seriam', 'seríamos', 'seu',
+  'seus', 'só', 'somos', 'sou', 'sua', 'suas', 'também', 'te', 'tem', 'tém',
+  'temos', 'tenha', 'tenham', 'tenhamos', 'tenho', 'terá', 'terão', 'terei',
+  'teremos', 'teria', 'teriam', 'teríamos', 'teu', 'teus', 'teve', 'tinha',
+  'tinham', 'tínhamos', 'tive', 'tivemos', 'tiver', 'tivera', 'tiveram',
+  'tivéramos', 'tiverem', 'tivermos', 'tivesse', 'tivessem', 'tivéssemos', 'tu',
+  'tua', 'tuas', 'um', 'uma', 'você', 'vocês', 'vos'
+]
+
+export const punct = [',', '"', "'", '.', '!']
+export const stopWords_ = [...stopWords, ...punct]
+
+export function collectTokenSet (hinario) {
+  const tokens = hinario.hinos.reduce((a, h) => {
+    if (h.tokens && h.tokens.pt) return [...a, ...h.tokens.pt]
+    return a
+  }, [])
+  const lower = tokens.map(t => t.toLowerCase())
+  return new Set(lower.filter(t => !stopWords_.includes(t)))
+}
+
+export function jaccard (setA, setB) {
+  const inter = [...setA].filter(x => setB.has(x))
+  const union = new Set([...setA, ...setB])
+  return inter.length / union.size
+}
+
+export function computeStats (hinario) {
+  const hymnTokenCounts = hinario.hinos.map(h => {
+    if (h.tokens && h.tokens.pt) return h.tokens.pt.length
+    return 0
+  })
+  const tokens = hinario.hinos.reduce((a, h) => {
+    if (h.tokens && h.tokens.pt) return [...a, ...h.tokens.pt]
+    return a
+  }, [])
+  const hymnsCount = hinario.hinos.length
+  const tokenCount = tokens.length
+  const uniqueTokens = new Set(tokens.map(t => t.toLowerCase()))
+  const avgTokensPerHymn = hymnsCount ? tokenCount / hymnsCount : 0
+  const uniqueTokenRatio = tokenCount ? uniqueTokens.size / tokenCount : 0
+  const longestHymn = hymnTokenCounts.length ? Math.max(...hymnTokenCounts) : 0
+  const shortestHymn = hymnTokenCounts.length ? Math.min(...hymnTokenCounts) : 0
+  return {
+    hymnsCount,
+    tokenCount,
+    uniqueTokens: uniqueTokens.size,
+    avgTokensPerHymn,
+    uniqueTokenRatio,
+    longestHymn,
+    shortestHymn
+  }
+}
+
+export function updateStats (hinario) {
+  const stats = computeStats(hinario)
+  const div = $('#statsDiv').empty()
+  $('<h3/>').text('Hymnal Stats').appendTo(div)
+  const ul = $('<ul/>').appendTo(div)
+  $('<li/>').text(`Hymns: ${stats.hymnsCount}`).appendTo(ul)
+  $('<li/>').text(`Total words: ${stats.tokenCount}`).appendTo(ul)
+  $('<li/>').text(`Unique words: ${stats.uniqueTokens}`).appendTo(ul)
+  $('<li/>').text(`Avg words/hymn: ${stats.avgTokensPerHymn.toFixed(2)}`).appendTo(ul)
+  $('<li/>').text(`Unique/word ratio: ${stats.uniqueTokenRatio.toFixed(2)}`).appendTo(ul)
+  $('<li/>').text(`Longest hymn: ${stats.longestHymn} words`).appendTo(ul)
+  $('<li/>').text(`Shortest hymn: ${stats.shortestHymn} words`).appendTo(ul)
+}
+
+export function computeCorpusStats (hinarios) {
+  const hymnalCount = hinarios.length
+  const hymns = hinarios.reduce((acc, h) => acc + h.hinos.length, 0)
+  const tokens = hinarios.reduce((a, h) => {
+    return [...a, ...h.hinos.reduce((x, hi) => {
+      if (hi.tokens && hi.tokens.pt) return [...x, ...hi.tokens.pt]
+      return x
+    }, [])]
+  }, [])
+  const tokenCount = tokens.length
+  const uniqueTokens = new Set(tokens.map(t => t.toLowerCase()).filter(t => !stopWords_.includes(t))).size
+  return { hymnalCount, hymns, tokenCount, uniqueTokens }
+}
+
+export function updateCorpusStats (stats) {
+  const div = $('#corpusStats').empty()
+  $('<h3/>').text('Corpus Stats').appendTo(div)
+  const ul = $('<ul/>').appendTo(div)
+  $('<li/>').text(`Hymnals: ${stats.hymnalCount}`).appendTo(ul)
+  $('<li/>').text(`Hymns: ${stats.hymns}`).appendTo(ul)
+  $('<li/>').text(`Total words: ${stats.tokenCount}`).appendTo(ul)
+  $('<li/>').text(`Unique words: ${stats.uniqueTokens}`).appendTo(ul)
+}
+
+export function updateSimilarHinarios (index, hinarioSets, hinarios) {
+  const base = hinarioSets[index]
+  const sims = hinarioSets.map((set, i) => {
+    if (i === index) return null
+    return { i, s: jaccard(base, set) }
+  }).filter(Boolean).sort((a, b) => b.s - a.s).slice(0, 3)
+  const div = $('#similarDiv').empty()
+  $('<h3/>').text('Similar Hymnals').appendTo(div)
+  const ul = $('<ul/>').appendTo(div)
+  sims.forEach(m => {
+    const h = hinarios[m.i]
+    const label = `${h.title} - ${h.person} (${m.s.toFixed(2)})`
+    $('<li/>').text(label).appendTo(ul)
+  })
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,37 @@
+import $ from 'jquery'
+
+export function showWordDetail (item) {
+  const [word, count] = item
+  $('#modalWord').text(`${word} - ${count}x`)
+  $('#wordModal').show()
+}
+
+export function setupUI () {
+  $(function () {
+    $('#wordModal .close').on('click', () => $('#wordModal').hide())
+    $('#wordModal').on('click', e => {
+      if (e.target.id === 'wordModal') $('#wordModal').hide()
+    })
+    $('#fullscreenBtn').on('click', () => {
+      const doc = document
+      if (!doc.fullscreenElement && !doc.webkitFullscreenElement && !doc.msFullscreenElement) {
+        const elem = document.documentElement
+        if (elem.requestFullscreen) {
+          elem.requestFullscreen()
+        } else if (elem.webkitRequestFullscreen) {
+          elem.webkitRequestFullscreen()
+        } else if (elem.msRequestFullscreen) {
+          elem.msRequestFullscreen()
+        }
+      } else {
+        if (doc.exitFullscreen) {
+          doc.exitFullscreen()
+        } else if (doc.webkitExitFullscreen) {
+          doc.webkitExitFullscreen()
+        } else if (doc.msExitFullscreen) {
+          doc.msExitFullscreen()
+        }
+      }
+    })
+  })
+}

--- a/src/wordcloud.js
+++ b/src/wordcloud.js
@@ -1,0 +1,27 @@
+import WordCloud from 'wordcloud'
+import { stopWords_ } from './stats.js'
+import { showWordDetail } from './ui.js'
+
+export function plotWordcloud (hinario) {
+  function getTokens (tokens) {
+    if (tokens && 'pt' in tokens) {
+      return tokens.pt
+    }
+    return []
+  }
+  const tokens = hinario.hinos.reduce((a, h) => [...a, ...getTokens(h.tokens)], [])
+  const tokensLower = tokens.map(t => t.toLowerCase())
+  const tokensSet = [...new Set(tokensLower)].filter(t => !stopWords_.includes(t))
+  const tokensHist = tokensSet.map(t => {
+    const count = tokensLower.filter(tt => t === tt).length
+    return { t, count }
+  })
+  tokensHist.sort((a, b) => a.count > b.count ? -1 : 1)
+  const list = tokensHist.map(i => [i.t, i.count])
+  WordCloud(document.getElementById('contentCanvas'), {
+    list,
+    weightFactor: 100 / tokensHist[0].count,
+    click: showWordDetail
+  })
+  window.th = { tokensHist, list }
+}


### PR DESCRIPTION
## Summary
- add `esmify` dev dependency
- bundle `src/index.js` instead of `scripts/main.js`
- modularize client code into `src/` directory

## Testing
- `npm run build`
- `npx standard`

------
https://chatgpt.com/codex/tasks/task_e_687b841704f08325bd8e1e45010b6594