### PR TITLE
Fix jaccard edge case

### DIFF
--- a/src/stats.js
+++ b/src/stats.js
@@ -41,8 +41,9 @@ export function collectTokenSet (hinario) {
 }
 
 export function jaccard (setA, setB) {
-  const inter = [...setA].filter(x => setB.has(x))
   const union = new Set([...setA, ...setB])
+  if (union.size === 0) return 0
+  const inter = [...setA].filter(x => setB.has(x))
   return inter.length / union.size
 }
 

--- a/tests/stats.test.mjs
+++ b/tests/stats.test.mjs
@@ -1,0 +1,8 @@
+import assert from 'assert'
+import { jaccard } from '../src/stats.js'
+
+assert.strictEqual(jaccard(new Set(), new Set()), 0)
+assert.strictEqual(jaccard(new Set([1, 2]), new Set([2, 3])), 1 / 3)
+assert.strictEqual(jaccard(new Set([1, 2]), new Set([3, 4])), 0)
+
+console.log('All tests passed')


### PR DESCRIPTION
## Summary
- avoid divide by zero when both sets empty in `jaccard`
- add tests for `jaccard`

## Testing
- `node tests/stats.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_687bfc22f178832585c99b7bab79bbd3