### PR TITLE
Add customizable wordcloud options

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,11 @@
 <body style="margin:0;font-family:Helvetica, arial">
     <div id="loading"><br/><br/><div style="padding-top:30%">LOADING...</div></div>
     <div id="selectDiv" class="centered"></div>
+    <div id="controls" class="centered">
+      <label for="wordCount">Words:</label>
+      <input id="wordCount" type="number" value="100" min="10" max="500" />
+      <label><input type="checkbox" id="includeStopwords" /> include stop words</label>
+    </div>
     <div id="contentContainer">
       <div id="canvasContainer">
         <canvas id="contentCanvas" width="1000" height="500"></canvas>
@@ -139,6 +144,15 @@
 #selectDiv select {
   padding: 5px;
   font-size: 1em;
+}
+
+#controls input[type="number"] {
+  padding: 5px;
+  font-size: 1em;
+  width: 80px;
+}
+#controls label {
+  margin-right: 10px;
 }
 
 /* The Modal (background) */

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import $ from 'jquery'
-import { setupUI } from './ui.js'
+import { setupUI, getWordcloudOptions } from './ui.js'
 import { plotWordcloud } from './wordcloud.js'
 import {
   collectTokenSet,
@@ -12,7 +12,13 @@ import { computeAuthorSets, drawAuthorNetwork } from './network.js'
 
 window.jQuery = $
 
-setupUI()
+let currentHinario
+function updateWordcloud () {
+  if (!currentHinario) return
+  plotWordcloud(currentHinario, getWordcloudOptions())
+}
+
+setupUI(updateWordcloud)
 
 let hinarioSets = []
 let corpusStats
@@ -30,10 +36,10 @@ $.getJSON('hinos/td.json', function (data) {
     .on('change', aself => {
       const ii = aself.currentTarget.value
       if (ii === '-1') return
-      const e = data.hinarios[ii]
-      plotWordcloud(e)
+      currentHinario = data.hinarios[ii]
+      updateWordcloud()
       updateSimilarHinarios(Number(ii), hinarioSets, data.hinarios)
-      updateStats(e)
+      updateStats(currentHinario)
     })
 
   window.adata = data
@@ -47,7 +53,8 @@ $.getJSON('hinos/td.json', function (data) {
     s.append($('<option/>', { class: 'pres' }).val(count).html(aname))
     $('#loading').hide()
   })
-  plotWordcloud(data.hinarios[0])
+  currentHinario = data.hinarios[0]
+  updateWordcloud()
   updateSimilarHinarios(0, hinarioSets, data.hinarios)
-  updateStats(data.hinarios[0])
+  updateStats(currentHinario)
 })

--- a/src/ui.js
+++ b/src/ui.js
@@ -6,7 +6,7 @@ export function showWordDetail (item) {
   $('#wordModal').show()
 }
 
-export function setupUI () {
+export function setupUI (onControlsChange = () => {}) {
   $(function () {
     $('#wordModal .close').on('click', () => $('#wordModal').hide())
     $('#wordModal').on('click', e => {
@@ -33,5 +33,15 @@ export function setupUI () {
         }
       }
     })
+
+    $('#wordCount').on('change', onControlsChange)
+    $('#includeStopwords').on('change', onControlsChange)
   })
+}
+
+export function getWordcloudOptions () {
+  return {
+    maxWords: Number($('#wordCount').val()) || undefined,
+    includeStopWords: $('#includeStopwords').is(':checked')
+  }
 }

--- a/src/wordcloud.js
+++ b/src/wordcloud.js
@@ -2,22 +2,35 @@ import WordCloud from 'wordcloud'
 import { stopWords_ } from './stats.js'
 import { showWordDetail } from './ui.js'
 
-export function plotWordcloud (hinario) {
+export function plotWordcloud (hinario, opts = {}) {
+  const { maxWords, includeStopWords = false } = opts
+
   function getTokens (tokens) {
     if (tokens && 'pt' in tokens) {
       return tokens.pt
     }
     return []
   }
+
   const tokens = hinario.hinos.reduce((a, h) => [...a, ...getTokens(h.tokens)], [])
-  const tokensLower = tokens.map(t => t.toLowerCase())
-  const tokensSet = [...new Set(tokensLower)].filter(t => !stopWords_.includes(t))
-  const tokensHist = tokensSet.map(t => {
-    const count = tokensLower.filter(tt => t === tt).length
-    return { t, count }
-  })
-  tokensHist.sort((a, b) => a.count > b.count ? -1 : 1)
+  let tokensLower = tokens.map(t => t.toLowerCase())
+  if (!includeStopWords) {
+    tokensLower = tokensLower.filter(t => !stopWords_.includes(t))
+  }
+
+  const freq = {}
+  tokensLower.forEach(t => { freq[t] = (freq[t] || 0) + 1 })
+  let tokensHist = Object.entries(freq).map(([t, count]) => ({ t, count }))
+  tokensHist.sort((a, b) => (a.count > b.count ? -1 : 1))
+  const limit = maxWords || tokensHist.length
+  tokensHist = tokensHist.slice(0, limit)
   const list = tokensHist.map(i => [i.t, i.count])
+
+  if (!tokensHist.length) {
+    WordCloud(document.getElementById('contentCanvas'), { list: [] })
+    return
+  }
+
   WordCloud(document.getElementById('contentCanvas'), {
     list,
     weightFactor: 100 / tokensHist[0].count,


### PR DESCRIPTION
## Summary
- allow choosing stop word inclusion and max word count
- add controls in the UI to change these settings
- update event handling so wordcloud refreshes when values change

## Testing
- `node tests/stats.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_687c08e900948325a91c05687c0e9722