### PR TITLE
Add similarity threshold slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
       <label for="wordCount">Words:</label>
       <input id="wordCount" type="number" value="100" min="10" max="500" />
       <label><input type="checkbox" id="includeStopwords" /> include stop words</label>
+      <label for="jaccardThreshold">Similarity threshold: <span id="thresholdValue">0.05</span></label>
+      <input id="jaccardThreshold" type="range" min="0" max="1" step="0.01" value="0.05" />
     </div>
     <div id="contentContainer">
       <div id="canvasContainer">
@@ -150,6 +152,9 @@
   padding: 5px;
   font-size: 1em;
   width: 80px;
+}
+#controls input[type="range"] {
+  vertical-align: middle;
 }
 #controls label {
   margin-right: 10px;

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,11 @@ $.getJSON('hinos/td.json', function (data) {
   corpusStats = computeCorpusStats(data.hinarios)
   authorSets = computeAuthorSets(data.hinarios)
   updateCorpusStats(corpusStats)
+  $('#thresholdValue').text($('#jaccardThreshold').val())
+  $('#jaccardThreshold').on('input change', () => {
+    $('#thresholdValue').text($('#jaccardThreshold').val())
+    drawAuthorNetwork(authorSets)
+  })
   drawAuthorNetwork(authorSets)
   data.hinarios.forEach((i, count) => {
     const aname = `${i.title} - ${i.person}`

--- a/src/network.js
+++ b/src/network.js
@@ -1,3 +1,4 @@
+import $ from 'jquery'
 import { jaccard, stopWords_ } from './stats.js'
 /* global d3 */
 
@@ -15,20 +16,21 @@ export function computeAuthorSets (hinarios) {
   return Object.entries(authors).map(([name, toks]) => [name, new Set(toks)])
 }
 
-export function computeAuthorNetwork (authorSets) {
+export function computeAuthorNetwork (authorSets, threshold = 0.05) {
   const nodes = authorSets.map(([name], i) => ({ id: i, name }))
   const links = []
   for (let i = 0; i < authorSets.length; i++) {
     for (let j = i + 1; j < authorSets.length; j++) {
       const s = jaccard(authorSets[i][1], authorSets[j][1])
-      if (s > 0.05) links.push({ source: i, target: j, weight: s })
+      if (s >= threshold) links.push({ source: i, target: j, weight: s })
     }
   }
   return { nodes, links }
 }
 
 export function drawAuthorNetwork (authorSets) {
-  const { nodes, links } = computeAuthorNetwork(authorSets)
+  const threshold = Number($('#jaccardThreshold').val()) || 0.05
+  const { nodes, links } = computeAuthorNetwork(authorSets, threshold)
   const width = 400
   const height = 300
   const svg = d3.select('#authorNetwork').html('').append('svg')


### PR DESCRIPTION
## Summary
- add slider to HTML for author similarity threshold
- allow adjusting threshold in network visualization
- redraw author network when threshold slider changes

## Testing
- `npm run build`
- `node tests/stats.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_687c0a5081f48325ad4e0e907607392b