### PR TITLE
Add fullscreen toggle for author network

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -41,12 +41,31 @@
   height: 100vh;
 }
 
+:fullscreen #authorNetwork {
+  max-width: none;
+  width: 100vw;
+  height: 100vh;
+}
+
 #canvasContainer {
   position: relative;
   display: inline-block;
 }
 
+#networkContainer {
+  position: relative;
+  display: inline-block;
+}
+
 #fullscreenBtn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 5px 10px;
+  font-size: 0.8em;
+}
+
+#networkFullscreenBtn {
   position: absolute;
   top: 10px;
   right: 10px;

--- a/index.html
+++ b/index.html
@@ -34,7 +34,10 @@
     </div>
     <div id="corpusContainer">
       <div id="corpusStats"></div>
-      <div id="authorNetwork"></div>
+      <div id="networkContainer">
+        <div id="authorNetwork"></div>
+        <button id="networkFullscreenBtn" title="View network full screen">&#x26F6;</button>
+      </div>
     </div>
     <div id="wordModal" class="modal">
       <div class="modal-content">

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -12239,7 +12239,7 @@ function setupUI(onControlsChange = () => {}) {
     (0, _jquery.default)('#wordModal').on('click', e => {
       if (e.target.id === 'wordModal') (0, _jquery.default)('#wordModal').hide();
     });
-    (0, _jquery.default)('#fullscreenBtn').on('click', () => {
+    function toggleFullscreen() {
       const doc = document;
       if (!doc.fullscreenElement && !doc.webkitFullscreenElement && !doc.msFullscreenElement) {
         const elem = document.documentElement;
@@ -12259,7 +12259,9 @@ function setupUI(onControlsChange = () => {}) {
           doc.msExitFullscreen();
         }
       }
-    });
+    }
+    (0, _jquery.default)('#fullscreenBtn').on('click', toggleFullscreen);
+    (0, _jquery.default)('#networkFullscreenBtn').on('click', toggleFullscreen);
     (0, _jquery.default)('#wordCount').on('change', onControlsChange);
     (0, _jquery.default)('#includeStopwords').on('change', onControlsChange);
   });

--- a/src/ui.js
+++ b/src/ui.js
@@ -12,7 +12,7 @@ export function setupUI (onControlsChange = () => {}) {
     $('#wordModal').on('click', e => {
       if (e.target.id === 'wordModal') $('#wordModal').hide()
     })
-    $('#fullscreenBtn').on('click', () => {
+    function toggleFullscreen () {
       const doc = document
       if (!doc.fullscreenElement && !doc.webkitFullscreenElement && !doc.msFullscreenElement) {
         const elem = document.documentElement
@@ -32,7 +32,10 @@ export function setupUI (onControlsChange = () => {}) {
           doc.msExitFullscreen()
         }
       }
-    })
+    }
+
+    $('#fullscreenBtn').on('click', toggleFullscreen)
+    $('#networkFullscreenBtn').on('click', toggleFullscreen)
 
     $('#wordCount').on('change', onControlsChange)
     $('#includeStopwords').on('change', onControlsChange)


### PR DESCRIPTION
## Summary
- add a fullscreen button next to the author network container
- handle fullscreen toggling for both wordcloud and network via shared logic
- style the network fullscreen button and allow the network SVG to expand in fullscreen

## Testing
- `npx -y standard`
- `node tests/stats.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_687c174854b88325ad84c4e3874fa78b