### PR TITLE
Fix network redraw on fullscreen

### DIFF
--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -11998,12 +11998,15 @@ _jquery.default.getJSON('hinos/td.json', function (data) {
   corpusStats = (0, _stats.computeCorpusStats)(data.hinarios);
   authorSets = (0, _network.computeAuthorSets)(data.hinarios);
   (0, _stats.updateCorpusStats)(corpusStats);
+  const redrawNetwork = () => (0, _network.drawAuthorNetwork)(authorSets);
+  document.addEventListener('fullscreenchange', redrawNetwork);
+  window.addEventListener('resize', redrawNetwork);
   (0, _jquery.default)('#thresholdValue').text((0, _jquery.default)('#jaccardThreshold').val());
   (0, _jquery.default)('#jaccardThreshold').on('input change', () => {
     (0, _jquery.default)('#thresholdValue').text((0, _jquery.default)('#jaccardThreshold').val());
-    (0, _network.drawAuthorNetwork)(authorSets);
+    redrawNetwork();
   });
-  (0, _network.drawAuthorNetwork)(authorSets);
+  redrawNetwork();
   data.hinarios.forEach((i, count) => {
     const aname = `${i.title} - ${i.person}`;
     s.append((0, _jquery.default)('<option/>', {
@@ -12071,9 +12074,10 @@ function drawAuthorNetwork(authorSets) {
     nodes,
     links
   } = computeAuthorNetwork(authorSets, threshold);
-  const width = 400;
-  const height = 300;
-  const svg = d3.select('#authorNetwork').html('').append('svg').attr('width', width).attr('height', height);
+  const container = (0, _jquery.default)('#authorNetwork').html('');
+  const width = container.width();
+  const height = container.height() || width * 0.75;
+  const svg = container.append('svg').attr('width', width).attr('height', height);
   const simulation = d3.forceSimulation(nodes).force('link', d3.forceLink(links).distance(80).strength(d => d.weight)).force('charge', d3.forceManyBody().strength(-100)).force('center', d3.forceCenter(width / 2, height / 2));
   const link = svg.append('g').selectAll('line').data(links).enter().append('line').attr('stroke', '#999').attr('stroke-width', d => 1 + 4 * d.weight);
   const node = svg.append('g').selectAll('circle').data(nodes).enter().append('circle').attr('r', 5).attr('fill', 'steelblue').call(d3.drag().on('start', dragstarted).on('drag', dragged).on('end', dragended));

--- a/src/index.js
+++ b/src/index.js
@@ -47,12 +47,15 @@ $.getJSON('hinos/td.json', function (data) {
   corpusStats = computeCorpusStats(data.hinarios)
   authorSets = computeAuthorSets(data.hinarios)
   updateCorpusStats(corpusStats)
+  const redrawNetwork = () => drawAuthorNetwork(authorSets)
+  document.addEventListener('fullscreenchange', redrawNetwork)
+  window.addEventListener('resize', redrawNetwork)
   $('#thresholdValue').text($('#jaccardThreshold').val())
   $('#jaccardThreshold').on('input change', () => {
     $('#thresholdValue').text($('#jaccardThreshold').val())
-    drawAuthorNetwork(authorSets)
+    redrawNetwork()
   })
-  drawAuthorNetwork(authorSets)
+  redrawNetwork()
   data.hinarios.forEach((i, count) => {
     const aname = `${i.title} - ${i.person}`
     s.append($('<option/>', { class: 'pres' }).val(count).html(aname))

--- a/src/network.js
+++ b/src/network.js
@@ -31,9 +31,10 @@ export function computeAuthorNetwork (authorSets, threshold = 0.05) {
 export function drawAuthorNetwork (authorSets) {
   const threshold = Number($('#jaccardThreshold').val()) || 0.05
   const { nodes, links } = computeAuthorNetwork(authorSets, threshold)
-  const width = 400
-  const height = 300
-  const svg = d3.select('#authorNetwork').html('').append('svg')
+  const container = $('#authorNetwork').html('')
+  const width = container.width()
+  const height = container.height() || width * 0.75
+  const svg = container.append('svg')
     .attr('width', width)
     .attr('height', height)
 


### PR DESCRIPTION
## Summary
- allow author network to use container width and height
- redraw author network when fullscreen mode or window size changes

## Testing
- `node tests/stats.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_687e3a94b36083258053d3c3a04487c9