### PR TITLE
Fix D3 network rendering

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -31,10 +31,12 @@ export function computeAuthorNetwork (authorSets, threshold = 0.05) {
 export function drawAuthorNetwork (authorSets) {
   const threshold = Number($('#jaccardThreshold').val()) || 0.05
   const { nodes, links } = computeAuthorNetwork(authorSets, threshold)
-  const container = $('#authorNetwork').html('')
+  const container = $('#authorNetwork')
   const width = container.width()
   const height = container.height() || width * 0.75
-  const svg = container.append('svg')
+  container.empty()
+  const svg = d3.select('#authorNetwork')
+    .append('svg')
     .attr('width', width)
     .attr('height', height)
 


### PR DESCRIPTION
## Summary
- clear the author network container with jQuery but use `d3.select()` to create the SVG element

## Testing
- `node tests/stats.test.mjs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e520281f4832599d9c1ab470ad3fb