### PR TITLE
Fix slider placement with network

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -73,6 +73,23 @@
   font-size: 0.8em;
 }
 
+#networkControls {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 5px;
+  border-radius: 4px;
+}
+
+#networkControls label {
+  margin-right: 10px;
+}
+
+#networkControls input[type="range"] {
+  vertical-align: middle;
+}
+
 #similarDiv {
   max-width: 300px;
 }

--- a/index.html
+++ b/index.html
@@ -56,17 +56,6 @@
         ><input type="checkbox" id="includeStopwords" /> include stop
         words</label
       >
-      <label for="jaccardThreshold"
-        >Similarity threshold: <span id="thresholdValue">0.05</span></label
-      >
-      <input
-        id="jaccardThreshold"
-        type="range"
-        min="0"
-        max="1"
-        step="0.01"
-        value="0.05"
-      />
     </div>
     <div id="contentContainer">
       <div id="canvasContainer">
@@ -85,6 +74,19 @@
         <button id="networkFullscreenBtn" title="View network full screen">
           &#x26F6;
         </button>
+        <div id="networkControls">
+          <label for="jaccardThreshold"
+            >Similarity threshold: <span id="thresholdValue">0.05</span></label
+          >
+          <input
+            id="jaccardThreshold"
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            value="0.05"
+          />
+        </div>
       </div>
     </div>
     <div id="wordModal" class="modal">


### PR DESCRIPTION
## Summary
- move similarity slider so it's inside the network container
- style new `#networkControls` so the slider aligns with the network

## Testing
- `node tests/stats.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_687e840cddc883258c2f221dda834297