### PR TITLE
Highlight author of selected hymnal

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -121,7 +121,16 @@
   max-width: 300px;
 }
 
+#corpusComparison {
+  max-width: 300px;
+}
+
 #corpusStats ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+#corpusComparison ul {
   list-style-type: none;
   padding-left: 0;
 }

--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
       <h2>Corpus Overview</h2>
     <div id="corpusContainer">
       <div id="corpusStats"></div>
+      <div id="corpusComparison"></div>
       <div id="networkContainer">
         <div id="authorNetwork"></div>
         <button id="networkFullscreenBtn" title="View network full screen">

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,11 @@ import {
   computeCorpusStats,
   updateCorpusStats,
   updateStats,
-  updateSimilarHinarios
+  updateSimilarHinarios,
+  computeCorpusComparison,
+  updateCorpusComparison
 } from './stats.js'
-import { computeAuthorSets, drawAuthorNetwork } from './network.js'
+import { computeAuthorSets, drawAuthorNetwork, highlightAuthor } from './network.js'
 
 window.jQuery = $
 
@@ -75,6 +77,12 @@ $.getJSON('hinos/td.json', function (data) {
       updateWordcloud()
       updateSimilarHinarios(Number(ii), hinarioSets, data.hinarios)
       updateStats(currentHinario)
+      highlightAuthor(currentHinario.person)
+      if (corpusStats) {
+        const comp = computeCorpusComparison(currentHinario, corpusStats)
+        updateCorpusComparison(comp)
+      }
+      document.getElementById('corpusOverview').scrollIntoView({ behavior: 'smooth' })
     })
 
   window.adata = data
@@ -82,7 +90,10 @@ $.getJSON('hinos/td.json', function (data) {
   corpusStats = computeCorpusStats(data.hinarios)
   authorSets = computeAuthorSets(data.hinarios)
   updateCorpusStats(corpusStats)
-  const redrawNetwork = () => drawAuthorNetwork(authorSets)
+  const redrawNetwork = () => {
+    drawAuthorNetwork(authorSets)
+    if (currentHinario) highlightAuthor(currentHinario.person)
+  }
   document.addEventListener('fullscreenchange', redrawNetwork)
   window.addEventListener('resize', redrawNetwork)
   $('#thresholdValue').text($('#jaccardThreshold').val())
@@ -100,4 +111,7 @@ $.getJSON('hinos/td.json', function (data) {
   updateWordcloud()
   updateSimilarHinarios(0, hinarioSets, data.hinarios)
   updateStats(currentHinario)
+  highlightAuthor(currentHinario.person)
+  const comp = computeCorpusComparison(currentHinario, corpusStats)
+  updateCorpusComparison(comp)
 })

--- a/src/network.js
+++ b/src/network.js
@@ -1,5 +1,7 @@
 import $ from 'jquery'
 import { jaccard, stopWords_ } from './stats.js'
+
+let currentNetwork
 /* global d3 */
 
 export function computeAuthorSets (hinarios) {
@@ -166,4 +168,35 @@ export function drawAuthorNetwork (authorSets) {
         return 'steelblue'
       })
   }
+  currentNetwork = { link, node, nodes }
+}
+
+export function highlightAuthor (name) {
+  if (!currentNetwork) return
+  const { link, node, nodes } = currentNetwork
+  const d = nodes.find(n => n.name === name)
+  if (!d) return
+  const neigh = new Set()
+  link
+    .attr('stroke', l => {
+      if (l.source.id === d.id || l.target.id === d.id) {
+        neigh.add(l.source.id)
+        neigh.add(l.target.id)
+        return 'orange'
+      }
+      return '#999'
+    })
+    .attr('stroke-width', l => {
+      if (l.source.id === d.id || l.target.id === d.id) {
+        return (1 + 4 * l.weight) * 1.5
+      }
+      return 1 + 4 * l.weight
+    })
+
+  node
+    .attr('fill', n => {
+      if (n.id === d.id) return 'orange'
+      if (neigh.has(n.id)) return 'lightblue'
+      return 'steelblue'
+    })
 }

--- a/src/stats.js
+++ b/src/stats.js
@@ -127,3 +127,21 @@ export function updateSimilarHinarios (index, hinarioSets, hinarios) {
     $('<li/>').text(label).appendTo(ul)
   })
 }
+
+export function computeCorpusComparison (hinario, corpusStats) {
+  const hStats = computeStats(hinario)
+  return {
+    hymnsShare: corpusStats.hymns ? hStats.hymnsCount / corpusStats.hymns : 0,
+    tokenShare: corpusStats.tokenCount ? hStats.tokenCount / corpusStats.tokenCount : 0,
+    uniqueShare: corpusStats.uniqueTokens ? hStats.uniqueTokens / corpusStats.uniqueTokens : 0
+  }
+}
+
+export function updateCorpusComparison (stats) {
+  const div = $('#corpusComparison').empty()
+  $('<h3/>').text('Corpus Share').appendTo(div)
+  const ul = $('<ul/>').appendTo(div)
+  $('<li/>').text(`Hymns: ${(stats.hymnsShare * 100).toFixed(1)}%`).appendTo(ul)
+  $('<li/>').text(`Words: ${(stats.tokenShare * 100).toFixed(1)}%`).appendTo(ul)
+  $('<li/>').text(`Unique words: ${(stats.uniqueShare * 100).toFixed(1)}%`).appendTo(ul)
+}


### PR DESCRIPTION
## Summary
- add corpus comparison display to the UI
- keep track of author network and expose `highlightAuthor`
- highlight author node when hymnal is selected and scroll to the corpus section
- compute corpus comparison against selected hymnal
- style updates for new corpus comparison panel

## Testing
- `npm i`
- `make b`
- `node tests/stats.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_6889ce4d35748325875384f77fbd9654